### PR TITLE
Исправлена ошибка директивы Использовать.

### DIFF
--- a/src/ScriptEngine.HostedScript/DirectiveIgnorer.cs
+++ b/src/ScriptEngine.HostedScript/DirectiveIgnorer.cs
@@ -7,7 +7,10 @@ namespace ScriptEngine.HostedScript
     public class DirectiveIgnorer : List<string>, IDirectiveResolver
     {
 
-        public ICodeSource Source { get; set; }
+        public ICodeSource Source {
+            get { return null;  }
+            set { }
+        }
 
         public DirectiveIgnorer ()
         {

--- a/src/ScriptEngine.HostedScript/DirectiveMultiResolver.cs
+++ b/src/ScriptEngine.HostedScript/DirectiveMultiResolver.cs
@@ -7,7 +7,29 @@ namespace ScriptEngine.HostedScript
     public class DirectiveMultiResolver : List<IDirectiveResolver>, IDirectiveResolver
     {
 
-        public ICodeSource Source { get; set; }
+        public ICodeSource Source
+        {
+            get
+            {
+                foreach (var resolver in this)
+                {
+                    var result = resolver.Source;
+                    if (result != null)
+                    {
+                        return result;
+                    }
+                }
+
+                return null;
+            }
+            set
+            {
+                foreach (var resolver in this)
+                {
+                    resolver.Source = value;
+                }
+            }
+        }
 
         public DirectiveMultiResolver ()
         {


### PR DESCRIPTION
Исправлена передача данных об источнике кода в подчинённые объекты
коллекции распознавателя директив.
