### PR TITLE
Fixed #331: В deb-пакет добавлена зависимость от `mono-4.5`.

### DIFF
--- a/install/builders/deb/settings/control
+++ b/install/builders/deb/settings/control
@@ -7,7 +7,10 @@ Section: interpreters
 Description: 1Script execution engine.
   Cross-platform scripting engine
   for DevOps who use 1C:Enterprise Platform (http://1c-dn.com/1c_enterprise)
-Depends: mono-runtime, libmono-system-core4.0-cil, libmono-system4.0-cil,
-  libmono-corlib4.0-cil, libmono-i18n4.0-all
+Depends: mono-runtime,
+  libmono-system-core4.0-cil | libmono-system-core4.5-cil,
+  libmono-system4.0-cil | libmono-system4.5-cil,
+  libmono-corlib4.0-cil | libmono-corlib4.5-cil,
+  libmono-i18n4.0-all | libmono-i18n4.5-all
 Recommends: mono-complete
 Origin: https://bitbucket.org/EvilBeaver/1script/ 


### PR DESCRIPTION
В случае, если в системе отсутствует `mono-4.0`, будет установлена
версия `mono-4.5`.
