### PR TITLE
Исправлен баг при передаче параметров с пробелами (внутри кавычек) в Linux

### DIFF
--- a/install/builders/deb/oscript
+++ b/install/builders/deb/oscript
@@ -1,3 +1,3 @@
 #!/bin/sh
-mono /usr/share/oscript/bin/oscript.exe $@
+mono /usr/share/oscript/bin/oscript.exe "$@"
 

--- a/install/builders/deb/oscript-cgi
+++ b/install/builders/deb/oscript-cgi
@@ -4,5 +4,5 @@ if [ -z "$SCRIPT_FILENAME" ]; then
 	export SCRIPT_FILENAME=$1
 fi
 
-mono /usr/share/oscript/bin/oscript.exe -cgi $@
+mono /usr/share/oscript/bin/oscript.exe -cgi "$@"
 

--- a/install/builders/deb/oscript-opm
+++ b/install/builders/deb/oscript-opm
@@ -1,4 +1,4 @@
 #!/bin/sh
 OSPATH=/usr/share/oscript
-mono $OSPATH/bin/oscript.exe $OSPATH/lib/opm/src/opm.os $@
+mono $OSPATH/bin/oscript.exe $OSPATH/lib/opm/src/opm.os "$@"
 


### PR DESCRIPTION
В командной строке для oscript эти параметры передавались неверно

вставил код

``` bsl
        Для Каждого Элемент Из АргументыКоманднойСтроки Цикл
            Сообщить(СтрШаблон("<%1>", Элемент));
        КонецЦикла;
```

Запускаю
`oscript -encoding=utf-8 "/mnt/c/projects/1bdd/src/bdd.os" -name "Второй неверный сценарий дубль"`
получаю

```
<-name>
<Второй>
<неверный>
<сценарий>
<дубль>
```

получаю баг шелл-скрипта
сейчас стоит

```
#!/bin/sh
mono /usr/share/oscript/bin/oscript.exe $@
```

а нужно поставить кавычки  `"$@"`

```
#!/bin/sh
mono /usr/share/oscript/bin/oscript.exe "$@"
```

так сработало

![image](https://cloud.githubusercontent.com/assets/2920817/19199558/45d637f6-8ccd-11e6-992e-e5f3bf1eab5c.png)
