### PR TITLE
Fixes #343: useUnsafeHeaderParsing по-умолчанию установлено в Истину.

### DIFF
--- a/src/oscript/ScriptFileHelper.cs
+++ b/src/oscript/ScriptFileHelper.cs
@@ -1,4 +1,4 @@
-﻿/*----------------------------------------------------------
+/*----------------------------------------------------------
 This Source Code Form is subject to the terms of the 
 Mozilla Public License, v.2.0. If a copy of the MPL 
 was not distributed with this file, You can obtain one 
@@ -7,10 +7,9 @@ at http://mozilla.org/MPL/2.0/.
 using ScriptEngine.Environment;
 using ScriptEngine.HostedScript;
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Text;
+using System.Reflection;
 
 namespace oscript
 {
@@ -26,6 +25,62 @@ namespace oscript
                 return null;
         }
 
+        // http://www.cookcomputing.com/blog/archives/000556.html
+        public static bool SetAllowUnsafeHeaderParsing()
+        {
+            var aNetAssembly = Assembly.GetAssembly(typeof (System.Net.Configuration.SettingsSection));
+            if (aNetAssembly == null) {
+                return false;
+            }
+
+            var aSettingsType = aNetAssembly.GetType("System.Net.Configuration.SettingsSectionInternal");
+            if (aSettingsType == null) {
+                return false;
+            }
+
+            var anInstance = aSettingsType.InvokeMember("Section", BindingFlags.Static | BindingFlags.GetProperty | BindingFlags.NonPublic, null, null, new object[] {} );
+            if (anInstance == null) {
+                return false;
+            }
+
+            var aUseUnsafeHeaderParsing = aSettingsType.GetField("useUnsafeHeaderParsing", BindingFlags.NonPublic | BindingFlags.Instance);
+            if (aUseUnsafeHeaderParsing == null) {
+                return false;
+            }
+
+            aUseUnsafeHeaderParsing.SetValue(anInstance, true);
+            return true;
+        }
+
+        private static bool ConvertSettingValueToBool(string value, bool default_value = false)
+        {
+            if (value == null) {
+                return default_value;
+            }
+
+            if (string.Compare(value, "true", StringComparison.InvariantCultureIgnoreCase) == 0) {
+                return true;
+            }
+            if (string.Compare(value, "1", StringComparison.InvariantCultureIgnoreCase) == 0) {
+                return true;
+            }
+            if (string.Compare(value, "yes", StringComparison.InvariantCultureIgnoreCase) == 0) {
+                return true;
+            }
+
+            if (string.Compare(value, "false", StringComparison.InvariantCultureIgnoreCase) == 0) {
+                return false;
+            }
+            if (string.Compare(value, "0", StringComparison.InvariantCultureIgnoreCase) == 0) {
+                return false;
+            }
+            if (string.Compare(value, "no", StringComparison.InvariantCultureIgnoreCase) == 0) {
+                return false;
+            }
+
+            return default_value;
+        }
+
         public static void OnBeforeScriptRead(HostedScriptEngine engine)
         {
             var cfg = engine.GetWorkingConfig();
@@ -37,6 +92,12 @@ namespace oscript
                     engine.Loader.ReaderEncoding = FileOpener.SystemSpecificEncoding();
                 else
                     engine.Loader.ReaderEncoding = Encoding.GetEncoding(openerEncoding); 
+            }
+
+            var strictWebRequest = ConvertSettingValueToBool(cfg["http.strictWebRequest"]);
+            if (!strictWebRequest)
+            {
+                SetAllowUnsafeHeaderParsing();
             }
         }
     }

--- a/src/oscript/oscript.csproj
+++ b/src/oscript/oscript.csproj
@@ -82,6 +82,7 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
+    <Reference Include="System.Configuration" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\GlobalAssemblyInfo.cs">


### PR DESCRIPTION
В oscript.cfg добавлена настройка http.strictWebRequest. Если она не
установлена в Истину (1, true, yes), то настройка useUnsafeHeaderParsing
устанавливается в true.
