### PR TITLE
Управление необходимостью добавления BOM в текстовых файлах.

### DIFF
--- a/src/ScriptEngine.HostedScript/Library/TextEncodingEnum.cs
+++ b/src/ScriptEngine.HostedScript/Library/TextEncodingEnum.cs
@@ -110,7 +110,7 @@ namespace ScriptEngine.HostedScript.Library
             return EnumContextHelper.CreateEnumInstance<TextEncodingEnum>((t,v)=>new TextEncodingEnum(t,v));
         }
 
-        public static Encoding GetEncodingByName(string encoding, bool addBOM)
+        public static Encoding GetEncodingByName(string encoding, bool addBOM = true)
         {
             Encoding enc;
             if (encoding == null)

--- a/src/ScriptEngine.HostedScript/Library/TextEncodingEnum.cs
+++ b/src/ScriptEngine.HostedScript/Library/TextEncodingEnum.cs
@@ -128,20 +128,20 @@ namespace ScriptEngine.HostedScript.Library
                     // зависят от платформы x86\m68k\SPARC. Пока нет понимания как корректно это обработать.
                     // Сейчас сделано исходя из предположения что PlatformEndian должен быть LE поскольку 
                     // платформа x86 более широко распространена
-                    case "UTF16_PlatformEndian":
+                    case "UTF16_PLATFORMENDIAN":
                         enc = new UnicodeEncoding(false, addBOM);
                         break;
                     case "UTF-16BE":
-                    case "UTF16_OppositeEndian":
+                    case "UTF16_OPPOSITEENDIAN":
                         enc = new UnicodeEncoding(true, addBOM);
                         break;
                     case "UTF-32":
                     case "UTF-32LE":
-                    case "UTF32_PlatformEndian":
+                    case "UTF32_PLATFORMENDIAN":
                         enc = new UTF32Encoding(false, addBOM);
                         break;
                     case "UTF-32BE":
-                    case "UTF32_OppositeEndian":
+                    case "UTF32_OPPOSITEENDIAN":
                         enc = new UTF32Encoding(true, addBOM);
                         break;
                     default:

--- a/src/ScriptEngine.HostedScript/Library/TextEncodingEnum.cs
+++ b/src/ScriptEngine.HostedScript/Library/TextEncodingEnum.cs
@@ -110,10 +110,54 @@ namespace ScriptEngine.HostedScript.Library
             return EnumContextHelper.CreateEnumInstance<TextEncodingEnum>((t,v)=>new TextEncodingEnum(t,v));
         }
 
-        public static Encoding GetEncoding(IValue encoding)
+        public static Encoding GetEncodingByName(string encoding, bool addBOM)
+        {
+            Encoding enc;
+            if (encoding == null)
+                enc = new UTF8Encoding(addBOM);
+            else
+            {
+                switch (encoding.ToUpper())
+                {
+                    case "UTF-8":
+                        enc = new UTF8Encoding(addBOM);
+                        break;
+                    case "UTF-16":
+                    case "UTF-16LE":
+                    // предположительно, варианты UTF16_PlatformEndian\UTF16_OppositeEndian
+                    // зависят от платформы x86\m68k\SPARC. Пока нет понимания как корректно это обработать.
+                    // Сейчас сделано исходя из предположения что PlatformEndian должен быть LE поскольку 
+                    // платформа x86 более широко распространена
+                    case "UTF16_PlatformEndian":
+                        enc = new UnicodeEncoding(false, addBOM);
+                        break;
+                    case "UTF-16BE":
+                    case "UTF16_OppositeEndian":
+                        enc = new UnicodeEncoding(true, addBOM);
+                        break;
+                    case "UTF-32":
+                    case "UTF-32LE":
+                    case "UTF32_PlatformEndian":
+                        enc = new UTF32Encoding(false, addBOM);
+                        break;
+                    case "UTF-32BE":
+                    case "UTF32_OppositeEndian":
+                        enc = new UTF32Encoding(true, addBOM);
+                        break;
+                    default:
+                        enc = Encoding.GetEncoding(encoding);
+                        break;
+
+                }
+            }
+
+            return enc;
+        }
+
+        public static Encoding GetEncoding(IValue encoding, bool addBOM = true)
         {
             if (encoding.DataType == DataType.String)
-                return Encoding.GetEncoding(encoding.AsString());
+                return GetEncodingByName(encoding.AsString(), addBOM);
             else
             {
                 if (encoding.DataType != DataType.GenericValue)

--- a/src/ScriptEngine.HostedScript/Library/TextEncodingEnum.cs
+++ b/src/ScriptEngine.HostedScript/Library/TextEncodingEnum.cs
@@ -175,9 +175,9 @@ namespace ScriptEngine.HostedScript.Library
                 else if (encValue == encodingEnum.Oem)
                     enc = Encoding.GetEncoding(866);
                 else if (encValue == encodingEnum.Utf16)
-                    enc = new UnicodeEncoding(false, true);
+                    enc = new UnicodeEncoding(false, addBOM);
                 else if (encValue == encodingEnum.Utf8)
-                    enc = new UTF8Encoding(true);
+                    enc = new UTF8Encoding(addBOM);
                 else if (encValue == encodingEnum.Utf8NoBOM)
                     enc = new UTF8Encoding(false);
                 else if (encValue == encodingEnum.System)

--- a/src/ScriptEngine.HostedScript/Library/Xml/XmlWriterImpl.cs
+++ b/src/ScriptEngine.HostedScript/Library/Xml/XmlWriterImpl.cs
@@ -229,10 +229,13 @@ namespace ScriptEngine.HostedScript.Library.Xml
         }
 
         [ContextMethod("ОткрытьФайл","OpenFile")]
-		public void OpenFile(string path, string encoding = null)
+		public void OpenFile(string path, string encoding = null, IValue addBOM = null)
 		{
             Encoding enc;
-            enc = EncodingFromName(encoding);
+            if (addBOM == null)
+                enc = TextEncodingEnum.GetEncodingByName(encoding, true);
+            else
+                enc = TextEncodingEnum.GetEncodingByName(encoding, addBOM.AsBoolean());
 
             _writer = new XmlTextWriter(path, enc);
             _stringWriter = null;
@@ -242,8 +245,7 @@ namespace ScriptEngine.HostedScript.Library.Xml
         [ContextMethod("УстановитьСтроку","SetString")]
 		public void SetString(string encoding = null)
 		{
-            Encoding enc = EncodingFromName(encoding);
-
+            Encoding enc = TextEncodingEnum.GetEncodingByName(encoding, true);
             _stringWriter = new StringWriterWithEncoding(enc);            
             _writer = new XmlTextWriter(_stringWriter);
             SetDefaultOptions();
@@ -253,16 +255,6 @@ namespace ScriptEngine.HostedScript.Library.Xml
         {
             _writer.Indentation = INDENT_SIZE;
             this.Indent = true;
-        }
-
-        private static Encoding EncodingFromName(string encoding)
-        {
-            Encoding enc;
-            if (encoding == null)
-                enc = new UTF8Encoding(true);
-            else
-                enc = Encoding.GetEncoding(encoding);
-            return enc;
         }
 
         #endregion


### PR DESCRIPTION
В класс TextEncodingEnum добавлен новый открытый метод GetEncodingByName предназначенный для получения кодировки по имени с указанием необходимости добавить BOM для Unicode кодировок.

У метода GetEncoding класса TextEncodingEnum,  добавлен необязательный параметр addBOM, для возможности указания необходимости добавить BOM для Unicode кодировок.

Доработан метод ОткрытьФайл класса XmlWriterImpl для возможности задания третьего, необязательного параметра addBOM (С  некоторой версии появился в платформе).