### PR TITLE
Fixes #304: ночные сборки в AppVeyor.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,16 @@
-version: 1.0.15.{build}
+version: 1.0.16-alpha{build}
 pull_requests:
   do_not_increment_build_number: true
 configuration: Release
 platform: x86
+assembly_info:
+  patch: true
+  assembly_version: '{version}'
+  assembly_file_version: '{version}'
+  assembly_informational_version: '{version}'
+nuget:
+  project_feed: true
+  disable_publish_on_pr: true
 init:
 - ps: Set-WinSystemLocale ru-RU
 - ps: Start-Sleep -s 5
@@ -13,6 +21,7 @@ before_build:
 - nuget restore src/1Script_Mono.sln
 build:
   project: src/1Script_Mono.sln
+  publish_nuget: true
   verbosity: minimal
 test_script:
 - cmd: appveyor-runtests.cmd

--- a/src/GlobalAssemblyInfo.cs
+++ b/src/GlobalAssemblyInfo.cs
@@ -17,9 +17,9 @@ at http://mozilla.org/MPL/2.0/.
 [assembly: System.Reflection.AssemblyCompany("BeaverSoft")]
 [assembly: System.Reflection.AssemblyCopyright("Copyright (c) 2016 EvilBeaver")]
 [assembly: System.Reflection.AssemblyConfiguration("Commit 2a614c0")]
-[assembly: System.Reflection.AssemblyVersion("1.0.15.0")]
-[assembly: System.Reflection.AssemblyFileVersion("1.0.15.0")]
-[assembly: System.Reflection.AssemblyInformationalVersion("1.0.15.0")]
+[assembly: System.Reflection.AssemblyVersion("1.0.16.0")]
+[assembly: System.Reflection.AssemblyFileVersion("1.0.16.0")]
+[assembly: System.Reflection.AssemblyInformationalVersion("1.0.16.0")]
 
 
 


### PR DESCRIPTION
В AppVeyor можно содержать своё хранилище пакетов nuget - самое то для ночных сборок.
Как настроить AppVeyor:
 1. Добавить проект
 2. Settings - Nuget
 3. Установить имя канала (https://ci.appveyor.com/nuget/onescript, например)
 4. Включить галки "Project Feed" и "Do not publish NuGet package artifacts to account/project feeds on Pull Requests"

После очередной сборки появятся пакеты версии 1.0.16-alpha***, после выпуска официальной 1.0.16 эта версия согласно семвера будет старше любой 1.0.16-alpha и все компоненты, которые подцепляли альфа-сборки, спокойно перейдут на релизную версию.