### PR TITLE
Исправлен Dockerfile сборки

### DIFF
--- a/install/builders/deb/Dockerfile
+++ b/install/builders/deb/Dockerfile
@@ -3,10 +3,6 @@ FROM ubuntu:latest
 
 MAINTAINER sergey.batanov@dmpas.ru
 
-# чтобы запустить тесты
-RUN locale-gen --lang ru_RU.UTF-8
-ENV LANG ru_RU.UTF-8
-
 # Add mono repository
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF && \
 		echo "deb http://download.mono-project.com/repo/debian wheezy main" > /etc/apt/sources.list.d/mono-xamarin.list
@@ -24,7 +20,12 @@ RUN apt-get update && apt-get install -y \
 		debhelper\
 		lintian\
 		md5deep\
-		fakeroot
+		fakeroot \
+		locales
+
+# чтобы запустить тесты
+RUN locale-gen --lang ru_RU.UTF-8
+ENV LANG ru_RU.UTF-8
 
 ADD ./build.sh /root/
 ENTRYPOINT /root/build.sh


### PR DESCRIPTION
В `ubuntu:latest` не стало пакета `locales` по-умолчанию. Теперь надо его сначала поставить, а потом вызывать `locale-gen`.