### PR TITLE
Разрешено использование недоверенных сертификатов SSL

### DIFF
--- a/src/NUnitTests/TypeReflectionTests.cs
+++ b/src/NUnitTests/TypeReflectionTests.cs
@@ -1,4 +1,10 @@
-﻿using System;
+﻿/*----------------------------------------------------------
+This Source Code Form is subject to the terms of the 
+Mozilla Public License, v.2.0. If a copy of the MPL 
+was not distributed with this file, You can obtain one 
+at http://mozilla.org/MPL/2.0/.
+----------------------------------------------------------*/
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/ScriptEngine.HostedScript/Library/Http/HttpConnectionContext.cs
+++ b/src/ScriptEngine.HostedScript/Library/Http/HttpConnectionContext.cs
@@ -232,6 +232,11 @@ namespace ScriptEngine.HostedScript.Library.Http
                 request.Timeout = Timeout * 1000;
             }
 
+            if (uriBuilder.Scheme == HTTPS_SCHEME)
+            {
+                request.ServerCertificateValidationCallback = delegate { return true; };
+            }
+
             return request;
             
         }


### PR DESCRIPTION
При указании `"https://"` в URL отключается проверка сертификатов.