### PR TITLE
добавил зависимсоть mono-locale-extras

### DIFF
--- a/install/builders/rpm/oscript.spec
+++ b/install/builders/rpm/oscript.spec
@@ -11,6 +11,7 @@ Source0:        OneScript-%{version}.tar.gz
 BuildArch:      noarch
 BuildRequires:	wget
 Requires:		mono-core
+Requires:		mono-locale-extras
 
 %define _empty_manifest_terminate_build 0
 %define _subdir OneScript-%{version}


### PR DESCRIPTION
При свежей установке и использовании opm пишет такое, для исправления:
КРИТИЧНАЯОШИБКА - {Модуль /usr/share/oscript/lib/opm/src/Классы/УстановкаПакета.os / Ошибка в строке: 26 / Внешнее исключение (System.NotSupportedException): Encoding 866 data could not be found. Make sure you have correct international codeset assembly installed and enabled.}