### PR TITLE
Анализ SonarQube + ругань в пулл-реквесты

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,8 +27,12 @@ pipeline {
                 //
                 // Поэтому, применяем костыль с кастомным workspace
                 // см. https://issues.jenkins-ci.org/browse/JENKINS-34564
+                //
+                // А еще Jenkins под Windows постоянно добавляет в конец папки какую-то мусорную строку.
+                // Для этого отсекаем все, что находится после последнего дефиса
+                // см. https://issues.jenkins-ci.org/browse/JENKINS-40072
                 
-                ws("$workspace".replaceAll("%", "_"))
+                ws("$workspace".replaceAll("%", "_").replaceAll(/(-[^-]+$)/, ""))
                 {
                     checkout scm
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,7 +32,7 @@ pipeline {
                 // Для этого отсекаем все, что находится после последнего дефиса
                 // см. https://issues.jenkins-ci.org/browse/JENKINS-40072
                 
-                ws("$workspace".replaceAll("%", "_").replaceAll(/(-[^-]+$)/, ""))
+                ws(env.WORKSPACE.replaceAll("%", "_").replaceAll(/(-[^-]+$)/, ""))
                 {
                     checkout scm
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,7 +43,7 @@ pipeline {
                             sqScannerMsBuildHome = sqScannerMsBuildHome + "\\SonarQube.Scanner.MSBuild.exe";
                             def sonarcommandStart = "@" + sqScannerMsBuildHome + " begin /k:1script /n:OneScript /v:\"1.0.${env.ReleaseNumber}\"";
                             def makeAnalyzis = true
-                            if (env.BRANCH_NAME == "feature/sonar") {
+                            if (env.BRANCH_NAME == "develop") {
                                 echo 'Analysing develop branch'
                             } else if (env.BRANCH_NAME.startsWith("PR-")) {
                                 // Report PR issues           

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -59,8 +59,8 @@ pipeline {
                                 
                                 def repository = gitURL.tokenize("/")[2] + "/" + gitURL.tokenize("/")[3]
                                 repository = repository.tokenize(".")[0]
-                                withCredentials([[$class: 'StringBinding', credentialsId: 'github', variable: 'githubOAuth']]) {
-                                    sonarcommand = sonarcommand + " /d:sonar.analysis.mode=issues /d:sonar.github.pullRequest=${PRNumber} /d:sonar.github.repository=${repository} /d:sonar.github.oauth=${env.githubOAuth}"
+                                withCredentials([string(credentialsId: 'GithubOAUTHToken_ForSonar', variable: 'githubOAuth')]) {
+                                    sonarcommandStart = sonarcommandStart + " /d:sonar.analysis.mode=issues /d:sonar.github.pullRequest=${PRNumber} /d:sonar.github.repository=${repository} /d:sonar.github.oauth=${githubOAuth}"
                                 }
                             } else {
                                 makeAnalyzis = false

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -106,7 +106,7 @@ pipeline {
             agent { label 'windows' }
 
             steps {
-                ws("$workspace".replaceAll("%", "_"))
+                ws(env.WORKSPACE.replaceAll("%", "_").replaceAll(/(-[^-]+$)/, ""))
                 {
                     dir('install/build'){
                         deleteDir()
@@ -159,7 +159,7 @@ pipeline {
             }
             
             steps {
-                ws("$workspace".replaceAll("%", "_"))
+                ws(env.WORKSPACE.replaceAll("%", "_").replaceAll(/(-[^-]+$)/, ""))
                 {
                     dir('install/build'){
                         deleteDir()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,7 +41,7 @@ pipeline {
                         script {
                             def sqScannerMsBuildHome = tool 'sonar-scanner for msbuild';
                             sqScannerMsBuildHome = sqScannerMsBuildHome + "\\SonarQube.Scanner.MSBuild.exe";
-                            def sonarcommandStart = sqScannerMsBuildHome + " begin /k:1script /n:OneScript";
+                            def sonarcommandStart = "@" + sqScannerMsBuildHome + " begin /k:1script /n:OneScript /v:\"1.0.${env.ReleaseNumber}\"";
                             def makeAnalyzis = true
                             if (env.BRANCH_NAME == "feature/sonar") {
                                 echo 'Analysing develop branch'


### PR DESCRIPTION
https://sonar.silverbulleters.org/dashboard?id=1script

Ругань в пулл-реквесты пока будет идти под моим логином (пока я не найду токен от ci-бота).

Анализ настроен на девелоп-ветку + ветки, начинающиеся с "PR-" - так дженкинс собирает пулл-реквесты

Если смущает на сонаре название организации/хочется рулить настройками правил/профиля качества, то могу выделить отдельный проект в рамках существующей организации https://sonar.silverbulleters.org/organizations/sonar-opensource-add/projects?sort=-size и назначить туда Андрюху/Серегу админами профилей качества.