### PR TITLE
Добавление параметра ИспользованиеByteOrderMark в метод УстановитьТелоИзСтроки, объекта HTTPЗапрос

### DIFF
--- a/src/ScriptEngine.HostedScript/Library/ByteOrderMarkUsageEnum.cs
+++ b/src/ScriptEngine.HostedScript/Library/ByteOrderMarkUsageEnum.cs
@@ -1,8 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿/*----------------------------------------------------------
+This Source Code Form is subject to the terms of the 
+Mozilla Public License, v.2.0. If a copy of the MPL 
+was not distributed with this file, You can obtain one 
+at http://mozilla.org/MPL/2.0/.
+----------------------------------------------------------*/
 
 namespace ScriptEngine.HostedScript.Library
 {

--- a/src/ScriptEngine.HostedScript/Library/ByteOrderMarkUsageEnum.cs
+++ b/src/ScriptEngine.HostedScript/Library/ByteOrderMarkUsageEnum.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ScriptEngine.HostedScript.Library
+{
+    [EnumerationType("ИспользованиеByteOrderMark", "ByteOrderMarkUsage")]
+    public enum ByteOrderMarkUsageEnum
+    {
+        [EnumItem("Авто", "Auto")]
+        Auto,
+
+        [EnumItem("Использовать", "Use")]
+        Use,
+
+        [EnumItem("НеИспользовать", "DontUse")]
+        DontUse
+    }
+}

--- a/src/ScriptEngine.HostedScript/Library/Http/HttpRequestBodyString.cs
+++ b/src/ScriptEngine.HostedScript/Library/Http/HttpRequestBodyString.cs
@@ -15,13 +15,29 @@ namespace ScriptEngine.HostedScript.Library.Http
         string _data;
         Encoding _encoding;
         
-        public HttpRequestBodyString(string body, IValue encoding = null)
+        public HttpRequestBodyString(string body, IValue encoding = null, ByteOrderMarkUsageEnum bomUsage = ByteOrderMarkUsageEnum.Auto)
         {
             _data = body;
+
+            var addBom = false;
+
             if (encoding == null)
-                _encoding = new UTF8Encoding(true);
+            {
+                if (bomUsage == ByteOrderMarkUsageEnum.Use)
+                    addBom = true;
+                
+                _encoding = new UTF8Encoding(addBom);
+            }
             else
-                _encoding = TextEncodingEnum.GetEncoding(encoding);
+            {
+                if (encoding.AsString().Equals("utf-16", StringComparison.OrdinalIgnoreCase)
+                    || encoding.AsString().Equals("utf-32", StringComparison.OrdinalIgnoreCase) && bomUsage == ByteOrderMarkUsageEnum.Auto)
+                    addBom = true;
+                else
+                    addBom = bomUsage == ByteOrderMarkUsageEnum.Use;
+
+                _encoding = TextEncodingEnum.GetEncoding(encoding, addBom);
+            }
         }
 
         public IValue GetAsString()

--- a/src/ScriptEngine.HostedScript/Library/Http/HttpRequestContext.cs
+++ b/src/ScriptEngine.HostedScript/Library/Http/HttpRequestContext.cs
@@ -102,9 +102,9 @@ namespace ScriptEngine.HostedScript.Library.Http
         /// <param name="data">Строка с данными</param>
         /// <param name="encoding">КодировкаТекста или Строка. Кодировка в которой отправляются данные.</param>
         [ContextMethod("УстановитьТелоИзСтроки", "SetBodyFromString")]
-        public void SetBodyFromString(string data, IValue encoding = null)
+        public void SetBodyFromString(string data, IValue encoding = null, ByteOrderMarkUsageEnum bomUsage = ByteOrderMarkUsageEnum.Auto)
         {
-            SetBody(new HttpRequestBodyString(data, encoding));
+            SetBody(new HttpRequestBodyString(data, encoding, bomUsage));
         }
 
         [ContextMethod("ПолучитьТелоКакСтроку", "GetBodyAsString")]


### PR DESCRIPTION
По мотивам #677 

Логику работы параметра "Авто", сделал "1С:Совместимо"

> Авто (Auto)
> Описание:
> Автоматическое определение необходимости использования метки порядка байтов при кодировании строк в зависимости от кодировки.
> Метка используется для кодировок UTF-16 и UTF-32, и не используется для UTF-8, UTF-16LE/UTF-16BE, UTF-32LE/UTF-32BE и др.

ЗЫ. Есть предложения как тесты написать?