### PR TITLE
Исправление бага с некорректной работой неуправляемых ком объектов.

### DIFF
--- a/src/ScriptEngine/Machine/Contexts/COMWrapperContext.cs
+++ b/src/ScriptEngine/Machine/Contexts/COMWrapperContext.cs
@@ -106,7 +106,7 @@ namespace ScriptEngine.Machine.Contexts
 
         private static bool TypeIsRuntimeCallableWrapper(Type type)
         {
-            return type.FullName == "System.__ComObject"; // string, cause it's hidden type
+            return type.FullName == "System.__ComObject" || type.BaseType.FullName == "System.__ComObject"; // string, cause it's hidden type
         }
 
         public static object[] MarshalArguments(IValue[] arguments)


### PR DESCRIPTION
Исправление бага #670 
Добавил проверку на класс - предок, у управляемых ком объектов он будет либо System.Object либо родительский класс \ интерфейс.