### PR TITLE
fix #748: для ValueTableColumn убрано id и вся работа с ним

### DIFF
--- a/src/ScriptEngine.HostedScript/Library/ValueTable/ValueTableColumn.cs
+++ b/src/ScriptEngine.HostedScript/Library/ValueTable/ValueTableColumn.cs
@@ -23,11 +23,7 @@ namespace ScriptEngine.HostedScript.Library.ValueTable
         private int _width;
         private readonly WeakReference _owner;
 
-        // id нужен для правильной работы функции FindProperty.
-        // Порядковый номер колонки не может быть использовать из-за своей изменчивости.
-        private readonly int _id;
-
-        public ValueTableColumn(ValueTableColumnCollection Owner, int id, string Name, string Title, TypeDescription Type, int Width)
+        public ValueTableColumn(ValueTableColumnCollection Owner, string Name, string Title, TypeDescription Type, int Width)
         {
             _name = Name;
             _title = Title;
@@ -35,13 +31,6 @@ namespace ScriptEngine.HostedScript.Library.ValueTable
             _width = Width;
 
             _owner = new WeakReference(Owner);
-            _id = id;
-
-        }
-
-        public int ID
-        {
-            get { return _id; }
         }
 
         /// <summary>

--- a/src/ScriptEngine.HostedScript/Library/ValueTable/ValueTableRow.cs
+++ b/src/ScriptEngine.HostedScript/Library/ValueTable/ValueTableRow.cs
@@ -130,12 +130,7 @@ namespace ScriptEngine.HostedScript.Library.ValueTable
 
         public override int FindProperty(string name)
         {
-            ValueTableColumn C = Owner().Columns.FindColumnByName(name);
-            
-            if (C == null)
-                throw RuntimeException.PropNotFoundException(name);
-
-            return C.ID;
+            return Owner().Columns.FindProperty(name);
         }
 
         public override bool IsPropReadable(int propNum)
@@ -150,13 +145,13 @@ namespace ScriptEngine.HostedScript.Library.ValueTable
 
         public override IValue GetPropValue(int propNum)
         {
-            ValueTableColumn C = Owner().Columns.FindColumnById(propNum);
+            ValueTableColumn C = Owner().Columns.FindColumnByIndex(propNum);
             return TryValue(C);
         }
 
 		public override void SetPropValue(int propNum, IValue newVal)
 		{
-			ValueTableColumn C = Owner().Columns.FindColumnById(propNum);
+			ValueTableColumn C = Owner().Columns.FindColumnByIndex(propNum);
 			_data[C] = C.ValueType.AdjustValue(newVal);
 		}
 


### PR DESCRIPTION
Ошибка была связана с `ValueTableColumnCollection._internal_counter` (пре-инкремент при добавлении колонки).  Замечено также, что в некоторых функциях смешивалась работа с id колонки и индексом в списке.
Везде, где использовался id, переделано на индекс.
Отладчик заработал, тесты проходят, замедления не замечено.