### PR TITLE
Fix 861: типы параметров конструктора DataWriter

### DIFF
--- a/src/ScriptEngine.HostedScript/Library/Binary/BinaryDataContext.cs
+++ b/src/ScriptEngine.HostedScript/Library/Binary/BinaryDataContext.cs
@@ -19,7 +19,7 @@ namespace ScriptEngine.HostedScript.Library.Binary
     [ContextClass("ДвоичныеДанные", "BinaryData")]
     public class BinaryDataContext : AutoContext<BinaryDataContext>, IDisposable
     {
-        byte[] _buffer;
+        private byte[] _buffer;
 
         public BinaryDataContext(string filename)
         {
@@ -68,13 +68,7 @@ namespace ScriptEngine.HostedScript.Library.Binary
         }
 
 
-        public byte[] Buffer
-        {
-            get
-            {
-                return _buffer;
-            }
-        }
+        public byte[] Buffer => _buffer;
 
         public override string AsString()
         {

--- a/src/ScriptEngine.HostedScript/Library/Binary/DataWriter.cs
+++ b/src/ScriptEngine.HostedScript/Library/Binary/DataWriter.cs
@@ -46,7 +46,6 @@ namespace ScriptEngine.HostedScript.Library.Binary
             var fileStreamContext = append ? fileSubsystem.OpenForAppend(fileName) : fileSubsystem.OpenForWrite(fileName);
 
             _binaryWriter = new BinaryWriter(fileStreamContext.GetUnderlyingStream(), _workingEncoding);
-        
         }
 
         public DataWriter(IStreamWrapper streamObj, IValue textEncoding, ByteOrderEnum? byteOrder, string lineSplitter, string convertibleSplitterOfLines, bool writeBOM)
@@ -58,7 +57,6 @@ namespace ScriptEngine.HostedScript.Library.Binary
             TextEncoding = textEncoding;
 
             _binaryWriter = new BinaryWriter(streamObj.GetUnderlyingStream(), _workingEncoding);
-        
         }
 
         /// <summary>
@@ -92,13 +90,22 @@ namespace ScriptEngine.HostedScript.Library.Binary
         /// Если в начало файла или потока требуется записать метку порядка байтов (BOM) для используемой кодировки текста, то данный параметр должен иметь значение Истина.
         /// Значение по умолчанию: Ложь. </param>
         ///
-        [ScriptConstructor(Name = "На основании имени файла")]
-        public static DataWriter Constructor(IValue fileName, IValue textEncoding = null, ByteOrderEnum? byteOrder = null, string lineSplitter = null, bool append = false, string convertibleSplitterOfLines = null, bool writeBOM = false)
+        [ScriptConstructor]
+        public static DataWriter Constructor(IValue file_stream, IValue textEncoding = null, IValue byteOrder = null, IValue lineSplitter = null, IValue param5 = null, IValue param6 = null, IValue param7 = null)
         {
-            if(fileName.DataType == DataType.String)
-                return new DataWriter(fileName.AsString(), textEncoding, byteOrder, lineSplitter, append, convertibleSplitterOfLines, writeBOM);
+            if (file_stream.DataType == DataType.String)
+                return new DataWriter(file_stream.AsString(), textEncoding, 
+                            ContextValuesMarshaller.ConvertParam<ByteOrderEnum?>(byteOrder,null),
+                            ContextValuesMarshaller.ConvertParam<string>(lineSplitter),
+                            ContextValuesMarshaller.ConvertParam<bool>(param5),
+                            ContextValuesMarshaller.ConvertParam<string>(param6),
+                            ContextValuesMarshaller.ConvertParam<bool>(param7));
             else
-                return ConstructorByStream(fileName, textEncoding, byteOrder, lineSplitter, convertibleSplitterOfLines, writeBOM);
+                return ConstructorByStream(file_stream, textEncoding,
+                            ContextValuesMarshaller.ConvertParam<ByteOrderEnum?>(byteOrder,null),
+                            ContextValuesMarshaller.ConvertParam<string>(lineSplitter),
+                            ContextValuesMarshaller.ConvertParam<string>(param5),
+                            ContextValuesMarshaller.ConvertParam<bool>(param6));
         }
 
         /// <summary>
@@ -125,7 +132,7 @@ namespace ScriptEngine.HostedScript.Library.Binary
         /// Если в начало файла или потока требуется записать метку порядка байтов (BOM) для используемой кодировки текста, то данный параметр должен иметь значение Истина.
         /// Значение по умолчанию: Ложь. </param>
         ///
-        [ScriptConstructor(Name = "На основании потока")]
+        //[ScriptConstructor(Name = "На основании потока")]
         public static DataWriter ConstructorByStream(IValue stream, IValue textEncoding = null, ByteOrderEnum? byteOrder = null, string lineSplitter = null, string convertibleSplitterOfLines = null, bool writeBOM = false)
         {
             var streamObj = stream.AsObject() as IStreamWrapper;
@@ -136,7 +143,7 @@ namespace ScriptEngine.HostedScript.Library.Binary
 
             return new DataWriter(streamObj, textEncoding, byteOrder, lineSplitter, convertibleSplitterOfLines, writeBOM);
         }
-    
+
         /// <summary>
         /// 
         /// Кодировка текста по-умолчанию для данного экземпляра ЗаписьДанных.


### PR DESCRIPTION
Проблему с DataWriter закрывает, но кажется, что нужны какие-то глобальные изменения для обработки подобных случаев.
_NB:_ Атрибут `[ScriptConstructor(Name = "На основании потока")]` для `ConstructorByStream` закомментирован. Непонятно, что делать с блоком ///summary для описания двух вариантов вызова одного конструктора.