### PR TITLE
проверка параметров конструктора Массива

### DIFF
--- a/src/ScriptEngine.HostedScript/Library/ArrayImpl.cs
+++ b/src/ScriptEngine.HostedScript/Library/ArrayImpl.cs
@@ -218,7 +218,13 @@ namespace ScriptEngine.HostedScript.Library
             ArrayImpl cloneable = null;
             for (int dim = dimensions.Length - 1; dim >= 0; dim--)
             {
+                if (dimensions[dim] == null)
+                    throw RuntimeException.InvalidNthArgumentType(dim + 1);
+
                 int bound = (int)dimensions[dim].AsNumber();
+                if (bound <= 0)
+                    throw RuntimeException.InvalidNthArgumentValue(dim + 1);
+
                 var newInst = new ArrayImpl();
                 FillArray(newInst, bound);
                 if(cloneable != null)

--- a/src/ScriptEngine/Machine/RuntimeExceptions.cs
+++ b/src/ScriptEngine/Machine/RuntimeExceptions.cs
@@ -110,7 +110,12 @@ namespace ScriptEngine.Machine
             return new RuntimeException(String.Format("Неверный тип аргумента '{0}'", argName));
         }
 
-        public static RuntimeException InvalidArgumentType(int argNum, string argName="" )
+        public static RuntimeException InvalidNthArgumentType(int argNum)
+        {
+            return new RuntimeException(String.Format("Неверный тип аргумента номер {0}", argNum));
+        }
+
+        public static RuntimeException InvalidArgumentType(int argNum, string argName )
         {
             return new RuntimeException(String.Format("Неверный тип аргумента номер {0} '{1}'", argNum, argName ));
         }
@@ -118,6 +123,11 @@ namespace ScriptEngine.Machine
         public static RuntimeException InvalidArgumentValue()
         {
             return new RuntimeException("Неверное значение аргумента");
+        }
+
+        public static RuntimeException InvalidNthArgumentValue(int argNum)
+        {
+            return new RuntimeException(String.Format("Неверное значение аргумента номер {0}", argNum));
         }
 
         public static RuntimeException InvalidArgumentValue(object value)


### PR DESCRIPTION
1. При вызове конструктора Массива с параметром по умолчанию 
`Массив = Новый Массив( ,2);`
 падало с System.NullReferenceException вместо нормальной ошибки.
2. При вызове конструктора Массива с отрицательным или нулевым параметром (в т.ч. единственным)
`Массив = Новый Массив(1,-2);` или `Массив = Новый Массив(0);`
создавался пустой массив, а должна быть ошибка.
Добавлены функции в RuntimeException - надо бы пересмотреть ошибки "Неверный тип аргумента" и "Неверное значение аргумента" в других объектах: где сообщать номер, где значение, а где имя параметра.