### PR TITLE
возможен пустой оператор в начале тела модуля

### DIFF
--- a/src/ScriptEngine/Compiler/Compiler.cs
+++ b/src/ScriptEngine/Compiler/Compiler.cs
@@ -279,7 +279,12 @@ namespace ScriptEngine.Compiler
                         BuildModuleBody();
                     }
                 }
-                else if(_lastExtractedLexem.Type == LexemType.Directive)
+                else if (_lastExtractedLexem.Type == LexemType.EndOperator)
+                {
+                    isCodeEntered = true;
+                    BuildModuleBody();
+                }
+                else if (_lastExtractedLexem.Type == LexemType.Directive)
                 {
                     HandleDirective(isCodeEntered);
                     UpdateCompositeContext(); // костыль для #330


### PR DESCRIPTION
Разрешает конструкции вида
```BSL
процедура П1()
конецпроцедуры
;
П1()
```
```BSL
перем п;
;
```
или просто модуль, начинающийся с пустого оператора.