### PR TITLE
fix #699: инициализация свойств глобального контекста

### DIFF
--- a/src/ScriptEngine.HostedScript/Library/SystemGlobalContext.cs
+++ b/src/ScriptEngine.HostedScript/Library/SystemGlobalContext.cs
@@ -641,6 +641,9 @@ namespace ScriptEngine.HostedScript.Library
             out IVariable[] variables, 
             out MethodInfo[] methods)
         {
+            if (_state == null)
+                InitContextVariables();
+
             variables = _state;
             methods = new MethodInfo[_methods.Count];
             for (int i = 0; i < _methods.Count; i++)


### PR DESCRIPTION
Фактически, быстрая затычка. Эта инициализация должна быть где-то выше в цепочке вызовов.
_(Не существует ли хоть какое-нибудь описание внутренней структуры движка?)_