### PR TITLE
fix #911: добавление контекстов внешних компонент в глобальный

### DIFF
--- a/src/ScriptEngine.HostedScript/Library/SystemGlobalContext.cs
+++ b/src/ScriptEngine.HostedScript/Library/SystemGlobalContext.cs
@@ -179,7 +179,7 @@ namespace ScriptEngine.HostedScript.Library
         public void AttachAddIn(string dllPath)
         {
             var assembly = System.Reflection.Assembly.LoadFrom(dllPath);
-            EngineInstance.AttachAssembly(assembly, EngineInstance.Environment);
+            EngineInstance.AttachExternalAssembly(assembly, EngineInstance.Environment);
         }
 
         /// <summary>

--- a/src/ScriptEngine.HostedScript/LibraryLoader.cs
+++ b/src/ScriptEngine.HostedScript/LibraryLoader.cs
@@ -119,7 +119,8 @@ namespace ScriptEngine.HostedScript
         public void LoadLibrary(string dllPath)
         {
             var assembly = System.Reflection.Assembly.LoadFrom(dllPath);
-            _engine.AttachAssembly(assembly, _env);
+            _engine.AttachExternalAssembly(assembly, _env);
+
         }
 
         [ContextMethod("ДобавитьМакет", "AddTemplate")]

--- a/src/ScriptEngine/Compiler/Compiler.cs
+++ b/src/ScriptEngine/Compiler/Compiler.cs
@@ -73,38 +73,38 @@ namespace ScriptEngine.Compiler
         public ModuleImage Compile(ILexemGenerator lexer, ICompilerContext context)
         {
             _module = new ModuleImage();
-            _module.LoadAddress = context.TopIndex();
             _ctx = context;
             _lexer = lexer;
             
             BuildModule();
             CheckForwardedDeclarations();
 
+            _module.LoadAddress = _ctx.TopIndex();
             return _module;
         }
 
         public ModuleImage CompileExpression(ILexemGenerator lexer, ICompilerContext context)
         {
             _module = new ModuleImage();
-            _module.LoadAddress = context.TopIndex();
             _ctx = context;
             _lexer = lexer;
             NextToken();
             BuildExpression(Token.EndOfText);
 
+            _module.LoadAddress = _ctx.TopIndex();
             return _module;
         }
 
         public ModuleImage CompileExecBatch(ILexemGenerator lexer, ICompilerContext context)
         {
             _module = new ModuleImage();
-            _module.LoadAddress = context.TopIndex();
             _ctx = context;
             _lexer = lexer;
             NextToken();
             PushStructureToken(Token.EndOfText);
             BuildModuleBody();
 
+            _module.LoadAddress = _ctx.TopIndex();
             return _module;
         }
 

--- a/src/ScriptEngine/ScriptingEngine.cs
+++ b/src/ScriptEngine/ScriptingEngine.cs
@@ -46,6 +46,21 @@ namespace ScriptEngine
             ContextDiscoverer.DiscoverGlobalContexts(globalEnvironment, asm);
         }
 
+        public void AttachExternalAssembly(System.Reflection.Assembly asm, RuntimeEnvironment globalEnvironment)
+        {
+            ContextDiscoverer.DiscoverClasses(asm);
+
+            var lastCount = globalEnvironment.AttachedContexts.Count();
+            ContextDiscoverer.DiscoverGlobalContexts(globalEnvironment, asm);
+
+            var newCount = globalEnvironment.AttachedContexts.Count();
+            while (lastCount < newCount)
+            {
+                _machine.AttachContext(globalEnvironment.AttachedContexts[lastCount]);
+                ++lastCount;
+            }
+        }
+
         public RuntimeEnvironment Environment { get; set; }
 
         public void Initialize()


### PR DESCRIPTION
В загрузчиках ВК вызывается ScriptingEngine.AttachExternalAssembly(), которая проверяет, были ли добавлены глобальные контексты, и присоединяет их в ВМ.
В компиляторе адрес загрузки модуля устанавливается после завершения компиляции, т.к. если произошло добавление контекстов, адрес увеличился.