### PR TITLE
Исправлены ошибки в индексах

### DIFF
--- a/src/OneScript.Language/LexemTrie.cs
+++ b/src/OneScript.Language/LexemTrie.cs
@@ -76,16 +76,12 @@ namespace OneScript.Language
 
             switch (c)
             {
-                case 'ё':
-                    return 142;
                 case '%':
                     return 0;
-                case '=':
-                    return 20;
-                case '?':
-                    return 21;
                 case 'Ё':
-                    return 77;
+                    return 79;
+                case 'ё':
+                    return 144;
             }
 
             return -1;


### PR DESCRIPTION
`?` и  `=` были в интервале кодов 59-63
Индекс `ё` совпадал с `ю`
Индекс `Ё` совпадал с `y` - компилировалось и работало такое:
```bsl
Ёear(ТекущаяДата())
```
