### PR TITLE
Исправлена ошибка метода Записать() класса БуферДвоичныхДанных

### DIFF
--- a/src/ScriptEngine.HostedScript/Library/Binary/BinaryDataBuffer.cs
+++ b/src/ScriptEngine.HostedScript/Library/Binary/BinaryDataBuffer.cs
@@ -121,9 +121,9 @@ namespace ScriptEngine.HostedScript.Library.Binary
             ThrowIfReadonly();
 
             if (number == 0)
-                Array.Copy(bytes._buffer, _buffer, bytes._buffer.Length);
+                Array.Copy(bytes._buffer, 0, _buffer, position, bytes._buffer.Length);
             else
-                Array.Copy(bytes._buffer, _buffer, number);
+                Array.Copy(bytes._buffer, 0, _buffer, position, number);
         }
 
         private byte[] GetBytes<T>(T value, Converter<T, byte[]> leConverter, Converter<T, byte[]> beConverter, IValue byteOrder = null)


### PR DESCRIPTION
Исправлена ошибка метода Записать() класса БуферДвоичныхДанных (BinaryDataBuffer.Write()): Не учитывалась начальная позиция записи и запись происходила с 0 позиции целевого буфера.