### PR TITLE
Исправлена ошибка метода "Извлечь" класса "ЧтениеZipФайла":

### DIFF
--- a/src/ScriptEngine.HostedScript/Library/Zip/ZipReader.cs
+++ b/src/ScriptEngine.HostedScript/Library/Zip/ZipReader.cs
@@ -90,20 +90,10 @@ namespace ScriptEngine.HostedScript.Library.Zip
             var realEntry = entry.GetZipEntry();
             _zip.FlattenFoldersOnExtract = FlattenPathsOnExtraction(restorePaths);
             realEntry.Password = password;
-            
-            FileStream StreamToExtract = new FileStream(Path.Combine(destination, entry.Name), FileMode.Create);
-            
-            try
+
+            using (FileStream StreamToExtract = new FileStream(Path.Combine(destination, entry.Name), FileMode.Create))
             {
                 realEntry.Extract(StreamToExtract);
-            }
-            catch (Exception)
-            {
-                throw;
-            }
-            finally
-            {
-                StreamToExtract.Close();
             }
         }
 

--- a/src/ScriptEngine.HostedScript/Library/Zip/ZipReader.cs
+++ b/src/ScriptEngine.HostedScript/Library/Zip/ZipReader.cs
@@ -91,9 +91,9 @@ namespace ScriptEngine.HostedScript.Library.Zip
             _zip.FlattenFoldersOnExtract = FlattenPathsOnExtraction(restorePaths);
             realEntry.Password = password;
 
-            using (FileStream StreamToExtract = new FileStream(Path.Combine(destination, entry.Name), FileMode.Create))
+            using (FileStream streamToExtract = new FileStream(Path.Combine(destination, entry.Name), FileMode.Create))
             {
-                realEntry.Extract(StreamToExtract);
+                realEntry.Extract(streamToExtract);
             }
         }
 

--- a/src/ScriptEngine.HostedScript/Library/Zip/ZipReader.cs
+++ b/src/ScriptEngine.HostedScript/Library/Zip/ZipReader.cs
@@ -9,6 +9,7 @@ using ScriptEngine.Machine;
 using ScriptEngine.Machine.Contexts;
 using System;
 using System.Text;
+using System.IO;
 
 namespace ScriptEngine.HostedScript.Library.Zip
 {
@@ -89,7 +90,21 @@ namespace ScriptEngine.HostedScript.Library.Zip
             var realEntry = entry.GetZipEntry();
             _zip.FlattenFoldersOnExtract = FlattenPathsOnExtraction(restorePaths);
             realEntry.Password = password;
-            realEntry.Extract(destination);
+            
+            FileStream StreamToExtract = new FileStream(Path.Combine(destination, entry.Name), FileMode.Create);
+            
+            try
+            {
+                realEntry.Extract(StreamToExtract);
+            }
+            catch (Exception)
+            {
+                throw;
+            }
+            finally
+            {
+                StreamToExtract.Close();
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
в случае файла с некорректным указанием размера/контрольной суммы выбрасывалось исключение и создавался файл со случайным именем,
в 1С (или с использованием архиватора) исключение возникает, но файл создается с корректным именем.