### PR TITLE
fix (#997): Поведение методов массива "Добавить" и "Вставить" как в 1С

### DIFF
--- a/src/ScriptEngine.HostedScript/Library/ArrayImpl.cs
+++ b/src/ScriptEngine.HostedScript/Library/ArrayImpl.cs
@@ -103,13 +103,16 @@ namespace ScriptEngine.HostedScript.Library
         #endregion
 
         [ContextMethod("Добавить", "Add")]
-        public void Add(IValue value)
+        public void Add(IValue value = null)
         {
-            _values.Add(value);
+            if (value == null)
+                _values.Add(ValueFactory.Create());
+            else 
+                _values.Add(value);
         }
 
         [ContextMethod("Вставить", "Insert")]
-        public void Insert(int index, IValue value)
+        public void Insert(int index, IValue value =  null)
         {
             if (index < 0)
                 throw IndexOutOfBoundsException();
@@ -117,7 +120,10 @@ namespace ScriptEngine.HostedScript.Library
             if (index > _values.Count)
                 Extend(index - _values.Count);
 
-            _values.Insert(index, value);
+            if (value == null)
+                _values.Insert(index, ValueFactory.Create());
+            else
+                _values.Insert(index, value);
         }
 
         [ContextMethod("Найти", "Find")]

--- a/src/ScriptEngine.HostedScript/Library/ArrayImpl.cs
+++ b/src/ScriptEngine.HostedScript/Library/ArrayImpl.cs
@@ -112,7 +112,7 @@ namespace ScriptEngine.HostedScript.Library
         }
 
         [ContextMethod("Вставить", "Insert")]
-        public void Insert(int index, IValue value =  null)
+        public void Insert(int index, IValue value = null)
         {
             if (index < 0)
                 throw IndexOutOfBoundsException();


### PR DESCRIPTION
Для методов массива "Добавить" и "Вставить" реализовано необязательное указание параметра "Значение", поведение приведено в соответствие с поведением в 1С.