### PR TITLE
Получение текущего ЦветаТекста/Фона консоли в Try-Catch

### DIFF
--- a/src/ScriptEngine.HostedScript/Library/ConsoleContext.cs
+++ b/src/ScriptEngine.HostedScript/Library/ConsoleContext.cs
@@ -114,7 +114,14 @@ namespace ScriptEngine.HostedScript.Library
         {
             get
             {
-                return (CLREnumValueWrapper<ConsoleColor> )GlobalsManager.GetEnum<ConsoleColorEnum>().FromNativeValue(Console.ForegroundColor);
+                try
+                {
+                    return (CLREnumValueWrapper<ConsoleColor>)GlobalsManager.GetEnum<ConsoleColorEnum>().FromNativeValue(Console.ForegroundColor);
+                }
+                catch
+                {
+                    return null;
+                }
             }
             set
             {
@@ -128,7 +135,14 @@ namespace ScriptEngine.HostedScript.Library
         {
             get
             {
-                return (CLREnumValueWrapper<ConsoleColor>)GlobalsManager.GetEnum<ConsoleColorEnum>().FromNativeValue(Console.BackgroundColor);
+                try
+                {
+                    return (CLREnumValueWrapper<ConsoleColor>)GlobalsManager.GetEnum<ConsoleColorEnum>().FromNativeValue(Console.BackgroundColor);
+                }
+                catch
+                {
+                    return null;
+                }
             }
             set
             {

--- a/src/ScriptEngine.HostedScript/Library/ConsoleContext.cs
+++ b/src/ScriptEngine.HostedScript/Library/ConsoleContext.cs
@@ -118,7 +118,7 @@ namespace ScriptEngine.HostedScript.Library
                 {
                     return (CLREnumValueWrapper<ConsoleColor>)GlobalsManager.GetEnum<ConsoleColorEnum>().FromNativeValue(Console.ForegroundColor);
                 }
-                catch
+                catch (InvalidOperationException)
                 {
                     return null;
                 }
@@ -139,7 +139,7 @@ namespace ScriptEngine.HostedScript.Library
                 {
                     return (CLREnumValueWrapper<ConsoleColor>)GlobalsManager.GetEnum<ConsoleColorEnum>().FromNativeValue(Console.BackgroundColor);
                 }
-                catch
+                catch (InvalidOperationException)
                 {
                     return null;
                 }


### PR DESCRIPTION
<Fix for PowerShell>
https://t.me/oscript_library/32965

При получении из перечисления "неустановленного" цвета валится ошибка.
Характерно для PowerShell и при запуске Cmd из PS (в Cmd после установки цвета получение происходит корректно)