### PR TITLE
fix #1055: падение при отстуствующих параметрах

### DIFF
--- a/src/oscript/CmdLineHelper.cs
+++ b/src/oscript/CmdLineHelper.cs
@@ -25,7 +25,7 @@ namespace oscript
         public string Next()
         {
             _index++;
-            if (_index == _args.Length)
+            if (_index >= _args.Length)
                 return null;
 
             return _args[_index];


### PR DESCRIPTION
Было сломано в 4b00a26.
Всё равно упадёт после 0x7FFFFFFF вызовов `Next()`. Стоит ли предусмотреть?

