### PR TITLE
fix #1087: аннотации после директив препроцессора; проверка имени

### DIFF
--- a/src/OneScript.Language/LexicalAnalysis/AnnotationLexerState.cs
+++ b/src/OneScript.Language/LexicalAnalysis/AnnotationLexerState.cs
@@ -1,4 +1,4 @@
-/*----------------------------------------------------------
+﻿/*----------------------------------------------------------
 This Source Code Form is subject to the terms of the 
 Mozilla Public License, v.2.0. If a copy of the MPL 
 was not distributed with this file, You can obtain one 
@@ -7,11 +7,22 @@ at http://mozilla.org/MPL/2.0/.
 
 namespace OneScript.Language.LexicalAnalysis
 {
-    public class AnnotationLexerState : WordLexerState
+    public class AnnotationLexerState : LexerState
     {
+        WordLexerState _wordExtractor = new WordLexerState();
+        const string MESSAGE_ANNOTATION_EXPECTED = "Ожидается имя аннотации";
+
         public override Lexem ReadNextLexem(SourceCodeIterator iterator)
         {
-            var lexem = base.ReadNextLexem(iterator);
+            iterator.MoveNext();
+
+            if (!iterator.MoveToContent())
+                throw CreateExceptionOnCurrentLine(MESSAGE_ANNOTATION_EXPECTED, iterator);
+
+            if (!char.IsLetter(iterator.CurrentSymbol))
+                throw CreateExceptionOnCurrentLine(MESSAGE_ANNOTATION_EXPECTED, iterator);
+
+            var lexem = _wordExtractor.ReadNextLexem(iterator);
             lexem.Type = LexemType.Annotation;
             return lexem;
         }

--- a/src/OneScript.Language/LexicalAnalysis/FullSourceLexer.cs
+++ b/src/OneScript.Language/LexicalAnalysis/FullSourceLexer.cs
@@ -145,8 +145,6 @@ namespace OneScript.Language.LexicalAnalysis
             }
             else if (cs == SpecialChars.Annotation)
             {
-                _iterator.GetContents();
-                _iterator.MoveNext();
                 _state = _annotationState;
             }
             else


### PR DESCRIPTION
Пробелы между & и именем аннотации разрешаются.
Имя может быть любым допустимым идентификатором в т. ч. зарезервированным.
