### PR TITLE
fix #1118: переход к номеру строки условия цикла Пока

### DIFF
--- a/src/ScriptEngine/Compiler/Compiler.cs
+++ b/src/ScriptEngine/Compiler/Compiler.cs
@@ -965,10 +965,9 @@ namespace ScriptEngine.Compiler
 
         private void BuildWhileStatement()
         {
-            AddLineNumber(_lexer.CurrentLine);
-
             NextToken();
-            var conditionIndex = _module.Code.Count;
+            var conditionIndex = AddLineNumber(_lexer.CurrentLine);
+
             var loopRecord = NestedLoopInfo.New();
             loopRecord.startPoint = conditionIndex;
             _nestedLoops.Push(loopRecord);


### PR DESCRIPTION
Будет правильно показывать номер строки при ошибке на проверке условия.
Небольшая потеря в скорости.