### PR TITLE
Добавил "1C (BSL)" для поиска отладчика

### DIFF
--- a/src/VSCode.DebugAdapter/package.json
+++ b/src/VSCode.DebugAdapter/package.json
@@ -1,9 +1,9 @@
 {
   "name": "oscript-debug",
-  "displayName": "OneScript Debug",
+  "displayName": "OneScript Debug 1C (BSL)",
   "version": "0.7.1",
   "publisher": "EvilBeaver",
-  "description": "Visual Studio Code debugger extension for OneScript",
+  "description": "Visual Studio Code debugger extension for OneScript 1C (BSL)",
   "icon": "images/mono-debug-icon.png",
   "categories": [
     "Debuggers"

--- a/src/VSCode.DebugAdapter/package.json
+++ b/src/VSCode.DebugAdapter/package.json
@@ -1,9 +1,9 @@
 {
   "name": "oscript-debug",
-  "displayName": "OneScript Debug 1C (BSL)",
+  "displayName": "OneScript Debug (BSL)",
   "version": "0.7.1",
   "publisher": "EvilBeaver",
-  "description": "Visual Studio Code debugger extension for OneScript 1C (BSL)",
+  "description": "Visual Studio Code debugger extension for OneScript (BSL)",
   "icon": "images/mono-debug-icon.png",
   "categories": [
     "Debuggers"


### PR DESCRIPTION
Сценарий:
у меня не был установлен отладчик
я нажал Ф5, ВСКод предложили найти отладчик
автоматом подставила строку @category:"Debuggers" 1C (BSL) в панели расширений
и там нет нашего отладчика
есть только расширение Исполнитель от 1С

предложение - хорошо бы добавить свойства и нашему отладчику, чтобы быстро и сразу искался

![image](https://user-images.githubusercontent.com/2920817/134334323-e0d433e0-d8c9-4dc6-8c7d-02b98a24daa5.png)
