### PR TITLE
fix #1138:  Итератор по перечислениям

### DIFF
--- a/src/ScriptEngine.HostedScript/Library/Binary/StreamEnums.cs
+++ b/src/ScriptEngine.HostedScript/Library/Binary/StreamEnums.cs
@@ -10,48 +10,48 @@ namespace ScriptEngine.HostedScript.Library.Binary
     [EnumerationType("РежимОткрытияФайла", "FileOpenMode")]
     public enum FileOpenModeEnum
     {
-        [EnumItem("Дописать")]
-        Append,
-        [EnumItem("Обрезать")]
-        Truncate,
-        [EnumItem("Открыть")]
-        Open,
-        [EnumItem("ОткрытьИлиСоздать")]
-        OpenOrCreate,
-        [EnumItem("Создать")]
+        [EnumItem("Создать", "Create")]
         Create,
-        [EnumItem("СоздатьНовый")]
-        CreateNew
+        [EnumItem("СоздатьНовый", "CreateNew")]
+        CreateNew,
+        [EnumItem("Открыть", "Open")]
+        Open,
+        [EnumItem("ОткрытьИлиСоздать", "OpenOrCreate")]
+        OpenOrCreate,
+        [EnumItem("Обрезать", "Truncate")]
+        Truncate,
+        [EnumItem("Дописать", "Append")]
+        Append
     }
 
     [EnumerationType("ДоступКФайлу", "FileAccess")]
     public enum FileAccessEnum
     {
-        [EnumItem("Запись")]
-        Write,
-        [EnumItem("Чтение")]
+        [EnumItem("Чтение", "Read")]
         Read,
-        [EnumItem("ЧтениеИЗапись")]
+        [EnumItem("Запись", "Write")]
+        Write,
+        [EnumItem("ЧтениеИЗапись", "ReadAndWrite")]
         ReadAndWrite
     }
 
     [EnumerationType("ПозицияВПотоке", "StreamPosition")]
     public enum StreamPositionEnum
     {
-        [EnumItem("Начало")]
+        [EnumItem("Начало", "Begin")]
         Begin,
-        [EnumItem("Конец")]
-        End,
-        [EnumItem("Текущая")]
-        Current
+        [EnumItem("Текущая", "Current")]
+        Current,
+        [EnumItem("Конец", "End")]
+        End
     }
 
     [EnumerationType("ПорядокБайтов", "ByteOrder")]
     public enum ByteOrderEnum
     {
-        [EnumItem("BigEndian")]
-        BigEndian,
         [EnumItem("LittleEndian")]
-        LittleEndian
+        LittleEndian,
+        [EnumItem("BigEndian")]
+        BigEndian
     }
 }

--- a/src/ScriptEngine.HostedScript/Library/ConsoleColorEnum.cs
+++ b/src/ScriptEngine.HostedScript/Library/ConsoleColorEnum.cs
@@ -46,6 +46,9 @@ namespace ScriptEngine.HostedScript.Library
             var type = TypeManager.RegisterType("ПеречислениеЦветКонсоли", typeof(ConsoleColorEnum));
             var enumValueType = TypeManager.RegisterType("ЦветКонсоли", typeof(CLREnumValueWrapper<ConsoleColor>));
 
+            TypeManager.RegisterAliasFor(type, "EnumerationConsoleColor");
+            TypeManager.RegisterAliasFor(enumValueType, "ConsoleColor");
+
             instance = new ConsoleColorEnum(type, enumValueType);
 
             instance.AddValue("Белый", "White", new CLREnumValueWrapper<ConsoleColor>(instance, ConsoleColor.White));

--- a/src/ScriptEngine.HostedScript/Library/DriveInfo/DriveTypeEnum.cs
+++ b/src/ScriptEngine.HostedScript/Library/DriveInfo/DriveTypeEnum.cs
@@ -35,6 +35,9 @@ namespace ScriptEngine.HostedScript.Library.DriveInfo
             var type = TypeManager.RegisterType("ПеречислениеТипДиска", typeof(DriveTypeEnum));
             var enumValueType = TypeManager.RegisterType("ТипДиска", typeof(CLREnumValueWrapper<System.IO.DriveType>));
 
+            TypeManager.RegisterAliasFor(type, "EnumerationDriveType");
+            TypeManager.RegisterAliasFor(enumValueType, "DriveType");
+
             instance = new DriveTypeEnum(type, enumValueType);
 
             instance.AddValue("Неизвестный", "Unknown", new CLREnumValueWrapper<System.IO.DriveType>(instance, System.IO.DriveType.Unknown));

--- a/src/ScriptEngine.HostedScript/Library/Hash/HashFunctionEnum.cs
+++ b/src/ScriptEngine.HostedScript/Library/Hash/HashFunctionEnum.cs
@@ -14,74 +14,33 @@ namespace ScriptEngine.HostedScript.Library.Hash
     [SystemEnum("ХешФункция", "HashFunction")]
     public class HashFunctionEnum : EnumerationContext
     {
+        const string CRC32 = "CRC32";
         const string MD5 = "MD5";
         const string SHA1 = "SHA1";
         const string SHA256 = "SHA256";
-        const string SHA384 = "SHA384";
         const string SHA512 = "SHA512";
-        const string CRC32 = "CRC32";
-
-
-        [EnumValue(MD5)]
-        public EnumerationValue Md5
-        {
-            get
-            {
-                return this[MD5];
-            }
-        }
-
-
-        [EnumValue(SHA1)]
-        public EnumerationValue Sha1
-        {
-            get
-            {
-                return this[SHA1];
-            }
-        }
-
-
-        [EnumValue(SHA256)]
-        public EnumerationValue Sha256
-        {
-            get
-            {
-                return this[SHA256];
-            }
-        }
-
-
-        [EnumValue(SHA384)]
-        public EnumerationValue Sha384
-        {
-            get
-            {
-                return this[SHA384];
-            }
-        }
-
-
-        [EnumValue(SHA512)]
-        public EnumerationValue Sha512
-        {
-            get
-            {
-                return this[SHA512];
-            }
-        }
+        const string SHA384 = "SHA384";
 
 
         [EnumValue(CRC32)]
-        public EnumerationValue Crc32
-        {
-            get
-            {
-                return this[CRC32];
-            }
-        }
+        public EnumerationValue Crc32 => this[CRC32];
+
+        [EnumValue(MD5)]
+        public EnumerationValue Md5 => this[MD5];
+
+        [EnumValue(SHA1)]
+        public EnumerationValue Sha1 => this[SHA1];
 
 
+        [EnumValue(SHA256)]
+        public EnumerationValue Sha256 => this[SHA256];
+
+        [EnumValue(SHA512)]
+        public EnumerationValue Sha512 => this[SHA512];
+
+
+        [EnumValue(SHA384)]
+        public EnumerationValue Sha384 => this[SHA384];
 
         private HashFunctionEnum(TypeDescriptor typeRepresentation, TypeDescriptor valuesType)
             : base(typeRepresentation, valuesType)

--- a/src/ScriptEngine.HostedScript/Library/Json/JSONCharactersEscapeMode.cs
+++ b/src/ScriptEngine.HostedScript/Library/Json/JSONCharactersEscapeMode.cs
@@ -18,31 +18,13 @@ namespace ScriptEngine.HostedScript.Library.Json
         }
 
         [EnumValue("Нет", "None")]
-        public EnumerationValue None
-        {
-            get
-            {
-                return this["Нет"];
-            }
-        }
-
-        [EnumValue("СимволыВнеASCII", "NotASCIISymbols")]
-        public EnumerationValue NotASCIISymbols
-        {
-            get
-            {
-                return this["СимволыВнеASCII"];
-            }
-        }
+        public EnumerationValue None => this["Нет"];
 
         [EnumValue("СимволыВнеBMP", "SymbolsNotInBMP")]
-        public EnumerationValue SymbolsNotInBMP
-        {
-            get
-            {
-                return this["СимволыВнеBMP"];
-            }
-        }
+        public EnumerationValue SymbolsNotInBMP => this["СимволыВнеBMP"];
+
+        [EnumValue("СимволыВнеASCII", "NotASCIISymbols")]
+        public EnumerationValue NotASCIISymbols => this["СимволыВнеASCII"];
 
         public static JSONCharactersEscapeModeEnum CreateInstance()
         {

--- a/src/ScriptEngine.HostedScript/Library/Json/JSONDateFormatEnum.cs
+++ b/src/ScriptEngine.HostedScript/Library/Json/JSONDateFormatEnum.cs
@@ -17,32 +17,14 @@ namespace ScriptEngine.HostedScript.Library.Json
         {
         }
 
+        [EnumValue("Microsoft")]
+        public EnumerationValue Microsoft => this["Microsoft"];
+
         [EnumValue("ISO")]
-        public EnumerationValue ISO
-        {
-            get
-            {
-                return this["ISO"];
-            }
-        }
+        public EnumerationValue ISO => this["ISO"];
 
         [EnumValue("JavaScript")]
-        public EnumerationValue JavaScript
-        {
-            get
-            {
-                return this["JavaScript"];
-            }
-        }
-
-        [EnumValue("Microsoft")]
-        public EnumerationValue Microsoft
-        {
-            get
-            {
-                return this["Microsoft"];
-            }
-        }
+        public EnumerationValue JavaScript => this["JavaScript"];
 
         public static JSONDateFormatEnum CreateInstance()
         {

--- a/src/ScriptEngine.HostedScript/Library/Json/JSONLineBreak.cs
+++ b/src/ScriptEngine.HostedScript/Library/Json/JSONLineBreak.cs
@@ -17,41 +17,17 @@ namespace ScriptEngine.HostedScript.Library.Json
         {
         }
 
-        [EnumValue("Unix")]
-        public EnumerationValue Unix
-        {
-            get
-            {
-                return this["Unix"];
-            }
-        }
-
         [EnumValue("Windows")]
-        public EnumerationValue Windows
-        {
-            get
-            {
-                return this["Windows"];
-            }
-        }
+        public EnumerationValue Windows => this["Windows"];
 
-        [EnumValue("Авто", "Auto")]
-        public EnumerationValue Auto
-        {
-            get
-            {
-                return this["Авто"];
-            }
-        }
+        [EnumValue("Unix")]
+        public EnumerationValue Unix => this["Unix"];
 
         [EnumValue("Нет", "None")]
-        public EnumerationValue None
-        {
-            get
-            {
-                return this["Нет"];
-            }
-        }
+        public EnumerationValue None => this["Нет"];
+
+        [EnumValue("Авто", "Auto")]
+        public EnumerationValue Auto => this["Авто"];
 
         public static JSONLineBreakEnum CreateInstance()
         {

--- a/src/ScriptEngine.HostedScript/Library/Json/JSONValueTypeEnum.cs
+++ b/src/ScriptEngine.HostedScript/Library/Json/JSONValueTypeEnum.cs
@@ -17,104 +17,38 @@ namespace ScriptEngine.HostedScript.Library.Json
         {
         }
 
-        [EnumValue("Null")]
-        public EnumerationValue Null
-        {
-            get
-            {
-                return this["Null"];
-            }
-        }
-
-        [EnumValue("Булево", "Boolean")]
-        public EnumerationValue Boolean
-        {
-            get
-            {
-                return this["Булево"];
-            }
-        }
-
-        [EnumValue("ИмяСвойства", "PropertyName")]
-        public EnumerationValue PropertyName
-        {
-            get
-            {
-                return this["ИмяСвойства"];
-            }
-        }
-
-        [EnumValue("Комментарий", "Comment")]
-        public EnumerationValue Comment
-        {
-            get
-            {
-                return this["Комментарий"];
-            }
-        }
-
-        [EnumValue("КонецМассива", "ArrayEnd")]
-        public EnumerationValue ArrayEnd
-        {
-            get
-            {
-                return this["КонецМассива"];
-            }
-        }
+        [EnumValue("НачалоОбъекта", "ObjectStart")]
+        public EnumerationValue ObjectStart => this["НачалоОбъекта"];
 
         [EnumValue("КонецОбъекта", "ObjectEnd")]
-        public EnumerationValue ObjectEnd
-        {
-            get
-            {
-                return this["КонецОбъекта"];
-            }
-        }
+        public EnumerationValue ObjectEnd => this["КонецОбъекта"];
 
         [EnumValue("НачалоМассива", "ArrayStart")]
-        public EnumerationValue ArrayStart
-        {
-            get
-            {
-                return this["НачалоМассива"];
-            }
-        }
+        public EnumerationValue ArrayStart => this["НачалоМассива"];
 
-        [EnumValue("НачалоОбъекта", "ObjectStart")]
-        public EnumerationValue ObjectStart
-        {
-            get
-            {
-                return this["НачалоОбъекта"];
-            }
-        }
+        [EnumValue("КонецМассива", "ArrayEnd")]
+        public EnumerationValue ArrayEnd => this["КонецМассива"];
 
-        [EnumValue("Ничего", "None")]
-        public EnumerationValue None
-        {
-            get
-            {
-                return this["Ничего"];
-            }
-        }
-
-        [EnumValue("Строка", "String")]
-        public EnumerationValue String
-        {
-            get
-            {
-                return this["Строка"];
-            }
-        }
+        [EnumValue("ИмяСвойства", "PropertyName")]
+        public EnumerationValue PropertyName => this["ИмяСвойства"];
 
         [EnumValue("Число", "Number")]
-        public EnumerationValue Number
-        {
-            get
-            {
-                return this["Число"];
-            }
-        }
+        public EnumerationValue Number => this["Число"];
+
+        [EnumValue("Строка", "String")]
+        public EnumerationValue String => this["Строка"];
+
+        [EnumValue("Булево", "Boolean")]
+        public EnumerationValue Boolean => this["Булево"];
+
+        [EnumValue("Null")]
+        public EnumerationValue Null => this["Null"];
+
+        [EnumValue("Комментарий", "Comment")]
+        public EnumerationValue Comment => this["Комментарий"];
+
+        [EnumValue("Ничего", "None")]
+        public EnumerationValue None => this["Ничего"];
 
         public static JSONValueTypeEnum CreateInstance()
         {

--- a/src/ScriptEngine.HostedScript/Library/MessageStatusEnum.cs
+++ b/src/ScriptEngine.HostedScript/Library/MessageStatusEnum.cs
@@ -13,20 +13,19 @@ namespace ScriptEngine.HostedScript.Library
         [EnumItem("БезСтатуса", "WithoutStatus")]
 		WithoutStatus,
 
-		[EnumItem("Важное", "Important")]
-		Important,
-
-		[EnumItem("Внимание", "Attention")]
-		Attention,
+		[EnumItem("Обычное", "Ordinary")]
+		Ordinary,
 
 		[EnumItem("Информация", "Information")]
 		Information,
 
-		[EnumItem("Обычное", "Ordinary")]
-		Ordinary,
+		[EnumItem("Внимание", "Attention")]
+		Attention,
+
+		[EnumItem("Важное", "Important")]
+		Important,
 
 		[EnumItem("ОченьВажное", "VeryImportant")]
 		VeryImportant
-
     }
 }

--- a/src/ScriptEngine.HostedScript/Library/MiscGlobalFunctions.cs
+++ b/src/ScriptEngine.HostedScript/Library/MiscGlobalFunctions.cs
@@ -155,22 +155,10 @@ namespace ScriptEngine.HostedScript.Library
         }
 
         [EnumValue(EV_SIMPLE, "URLEncoding")]
-        public EnumerationValue URLEncoding
-        {
-            get
-            {
-                return this[EV_SIMPLE];
-            }
-        }
+        public EnumerationValue URLEncoding => this[EV_SIMPLE];
 
         [EnumValue(EV_URL, "URLInURLEncoding")]
-        public EnumerationValue URLInURLEncoding
-        {
-            get
-            {
-                return this[EV_URL];
-            }
-        }
+        public EnumerationValue URLInURLEncoding => this[EV_URL];
 
         public static StringEncodingMethodEnum CreateInstance()
         {

--- a/src/ScriptEngine.HostedScript/Library/PlatformTypeEnum.cs
+++ b/src/ScriptEngine.HostedScript/Library/PlatformTypeEnum.cs
@@ -10,6 +10,12 @@ namespace ScriptEngine.HostedScript.Library
     [EnumerationType("ТипПлатформы", "PlatformType")]
     public enum PlatformTypeEnum
     {
+        [EnumItem("Windows_x86")]
+        Windows_x86,
+
+        [EnumItem("Windows_x86_64")]
+        Windows_x86_64,
+
         [EnumItem("Linux_x86")]
         Linux_x86,
         
@@ -21,12 +27,6 @@ namespace ScriptEngine.HostedScript.Library
 
         [EnumItem("MacOS_x86_64")]
         MacOS_x86_64, 
-
-        [EnumItem("Windows_x86")]
-        Windows_x86,
-
-        [EnumItem("Windows_x86_64")]
-        Windows_x86_64,
 
         [EnumItem("Unknown")]
         Unknown,

--- a/src/ScriptEngine.HostedScript/Library/SpecialFolderEnum.cs
+++ b/src/ScriptEngine.HostedScript/Library/SpecialFolderEnum.cs
@@ -30,6 +30,9 @@ namespace ScriptEngine.HostedScript.Library
             var type = TypeManager.RegisterType("ПеречислениеСпециальнаяПапка", typeof(SpecialFolderEnum));
             var enumValueType = TypeManager.RegisterType("СпециальнаяПапка", typeof(CLREnumValueWrapper<sysFolder>));
 
+            TypeManager.RegisterAliasFor(type, "EnumerationSpecialFolder");
+            TypeManager.RegisterAliasFor(enumValueType, "SpecialFolder");
+
             instance = new SpecialFolderEnum(type, enumValueType);
 
             instance.AddValue("МоиДокументы", "MyDocuments", new CLREnumValueWrapper<sysFolder>(instance, sysFolder.Personal));

--- a/src/ScriptEngine.HostedScript/Library/StringOperations.cs
+++ b/src/ScriptEngine.HostedScript/Library/StringOperations.cs
@@ -313,9 +313,9 @@ namespace ScriptEngine.HostedScript.Library
     [EnumerationType("НаправлениеПоиска", "SearchDirection")]
     public enum SearchDirection
     {
-        [EnumItem("СНачала")]
+        [EnumItem("СНачала", "FromBegin")]
         FromBegin,
-        [EnumItem("СКонца")]
+        [EnumItem("СКонца", "FromEnd")]
         FromEnd
     }
 

--- a/src/ScriptEngine.HostedScript/Library/Tasks/TaskStateEnum.cs
+++ b/src/ScriptEngine.HostedScript/Library/Tasks/TaskStateEnum.cs
@@ -12,13 +12,15 @@ namespace ScriptEngine.HostedScript.Library.Tasks
     [EnumerationType("СостояниеФоновогоЗадания", "BackgroundJobState")]
     public enum TaskStateEnum
     {
-        [EnumItem("НеВыполнялось", "NotRunned")]
-        NotRunned,
         [EnumItem("Активно", "Active")]
         Running,
         [EnumItem("Завершено", "Completed")]
         Completed,
         [EnumItem("ЗавершеноАварийно", "Failed")]
-        CompletedWithErrors
+        CompletedWithErrors,
+        [EnumItem("Отменено", "Canceled")]
+        Canceled,
+        [EnumItem("НеВыполнялось", "NotRunned")]
+        NotRunned
     }
 }

--- a/src/ScriptEngine.HostedScript/Library/TextEncodingEnum.cs
+++ b/src/ScriptEngine.HostedScript/Library/TextEncodingEnum.cs
@@ -13,71 +13,35 @@ namespace ScriptEngine.HostedScript.Library
     [SystemEnum("КодировкаТекста", "TextEncoding")]
     public class TextEncodingEnum : EnumerationContext
     {
-        private const string ENCODING_ANSI = "ANSI";
-        private const string ENCODING_OEM = "OEM";
         private const string ENCODING_UTF16 = "UTF16";
         private const string ENCODING_UTF8 = "UTF8";
-        private const string ENCODING_UTF8NoBOM = "UTF8NoBOM";
+        private const string ENCODING_ANSI = "ANSI";
+        private const string ENCODING_OEM = "OEM";
         private const string ENCODING_SYSTEM = "Системная";
+        private const string ENCODING_UTF8NoBOM = "UTF8NoBOM";
 
         private TextEncodingEnum(TypeDescriptor typeRepresentation, TypeDescriptor valuesType)
             : base(typeRepresentation, valuesType)
         {
         }
 
-        [EnumValue(ENCODING_ANSI)]
-        public EnumerationValue Ansi
-        {
-            get
-            {
-                return this[ENCODING_ANSI];
-            }
-        }
-
-        [EnumValue(ENCODING_OEM)]
-        public EnumerationValue Oem
-        {
-            get
-            {
-                return this[ENCODING_OEM];
-            }
-        }
-
         [EnumValue(ENCODING_UTF16)]
-        public EnumerationValue Utf16
-        {
-            get
-            {
-                return this[ENCODING_UTF16];
-            }
-        }
+        public EnumerationValue Utf16 => this[ENCODING_UTF16];
 
         [EnumValue(ENCODING_UTF8)]
-        public EnumerationValue Utf8
-        {
-            get
-            {
-                return this[ENCODING_UTF8];
-            }
-        }
+        public EnumerationValue Utf8 => this[ENCODING_UTF8];
 
-        [EnumValue(ENCODING_UTF8NoBOM)]
-        public EnumerationValue Utf8NoBOM
-        {
-            get
-            {
-                return this[ENCODING_UTF8NoBOM];
-            }
-        }
+        [EnumValue(ENCODING_ANSI)]
+        public EnumerationValue Ansi => this[ENCODING_ANSI];
+
+        [EnumValue(ENCODING_OEM)]
+        public EnumerationValue Oem => this[ENCODING_OEM];
 
         [EnumValue(ENCODING_SYSTEM, "System")]
-        public EnumerationValue System
-        {
-            get
-            {
-                return this[ENCODING_SYSTEM];
-            }
-        }
+        public EnumerationValue System => this[ENCODING_SYSTEM];
+
+        [EnumValue(ENCODING_UTF8NoBOM)]
+        public EnumerationValue Utf8NoBOM => this[ENCODING_UTF8NoBOM];
 
         public EnumerationValue GetValue(Encoding encoding)
         {

--- a/src/ScriptEngine.HostedScript/Library/TypeDescription/AllowedLengthEnum.cs
+++ b/src/ScriptEngine.HostedScript/Library/TypeDescription/AllowedLengthEnum.cs
@@ -10,10 +10,10 @@ namespace ScriptEngine.HostedScript.Library
 	[EnumerationType("ДопустимаяДлина", "AllowedLength")]
 	public enum AllowedLengthEnum
 	{
+		[EnumItem("Фиксированная", "Fixed")]
+		Fixed,
+
 		[EnumItem("Переменная", "Variable")]
 		Variable,
-
-		[EnumItem("Фиксированная", "Fixed")]
-		Fixed
 	}
 }

--- a/src/ScriptEngine.HostedScript/Library/TypeDescription/DateFractionsEnum.cs
+++ b/src/ScriptEngine.HostedScript/Library/TypeDescription/DateFractionsEnum.cs
@@ -13,10 +13,10 @@ namespace ScriptEngine.HostedScript.Library
 		[EnumItem("Дата", "Date")]
 		Date,
 
-		[EnumItem("ДатаВремя", "DateTime")]
-		DateTime,
-
 		[EnumItem("Время", "Time")]
-		Time
+		Time,
+
+		[EnumItem("ДатаВремя", "DateTime")]
+		DateTime
 	}
 }

--- a/src/ScriptEngine.HostedScript/Library/XDTO/XMLForm.cs
+++ b/src/ScriptEngine.HostedScript/Library/XDTO/XMLForm.cs
@@ -7,16 +7,16 @@ at http://mozilla.org/MPL/2.0/.
 
 namespace ScriptEngine.HostedScript.Library.XDTO
 {
-    [EnumerationType("XMLForm", "ФормаXML")]
+    [EnumerationType("ФормаXML", "XMLForm")]
     public enum XMLForm
     {
-        [EnumItem("Element", "Элемент")]
+        [EnumItem("Атрибут", "Attribute")]
+        Attribute,
+
+        [EnumItem("Элемент", "Element")]
         Element,
 
-        [EnumItem("Text", "Текст")]
-        Text,
-
-        [EnumItem("Attribute", "Атрибут")]
-        Attribute
+        [EnumItem("Текст", "Text")]
+        Text
     }
 }

--- a/src/ScriptEngine.HostedScript/Library/XMLSchema/Enumerations/XSAttributeUseCategory.cs
+++ b/src/ScriptEngine.HostedScript/Library/XMLSchema/Enumerations/XSAttributeUseCategory.cs
@@ -9,19 +9,19 @@ using System.Xml.Schema;
 
 namespace ScriptEngine.HostedScript.Library.XMLSchema
 {
-    [EnumerationType("XSAttributeUseCategory", "КатегорияИспользованияАтрибутаXS")]
+    [EnumerationType("КатегорияИспользованияАтрибутаXS","XSAttributeUseCategory")]
     public enum XSAttributeUseCategory
     {
-        [EnumItem("EmptyRef", "ПустаяСсылка")]
-        EmptyRef = XmlSchemaUse.None,
-
-        [EnumItem("Optional", "Необязательно")]
+        [EnumItem("Необязательно", "Optional")]
         Optional = XmlSchemaUse.Optional,
 
-        [EnumItem("Prohibited", "Запрещено")]
+        [EnumItem("Запрещено", "Prohibited")]
         Prohibited = XmlSchemaUse.Prohibited,
 
-        [EnumItem("Required", "Обязательно")]
-        Required = XmlSchemaUse.Required
+        [EnumItem("Обязательно", "Required")]
+        Required = XmlSchemaUse.Required,
+
+        [EnumItem("ПустаяСсылка", "EmptyRef")]
+        EmptyRef = XmlSchemaUse.None
     }
 }

--- a/src/ScriptEngine.HostedScript/Library/XMLSchema/Enumerations/XSComplexFinal.cs
+++ b/src/ScriptEngine.HostedScript/Library/XMLSchema/Enumerations/XSComplexFinal.cs
@@ -49,16 +49,16 @@ namespace ScriptEngine.HostedScript.Library.XMLSchema
 
         public static EnumerationXSComplexFinal CreateInstance()
         {
-            TypeDescriptor type = TypeManager.RegisterType("EnumerationXSComplexFinal", typeof(EnumerationXSComplexFinal));
-            TypeDescriptor enumValueType = TypeManager.RegisterType("XSComplexFinal", typeof(XSComplexFinal));
+            TypeDescriptor type = TypeManager.RegisterType("ПеречислениеЗавершенностьСоставногоТипаXS", typeof(EnumerationXSComplexFinal));
+            TypeDescriptor enumValueType = TypeManager.RegisterType("ЗавершенностьСоставногоТипаXS", typeof(XSComplexFinal));
 
-            TypeManager.RegisterAliasFor(type, "ПеречислениеЗавершенностьСоставногоТипаXS");
-            TypeManager.RegisterAliasFor(enumValueType, "ЗавершенностьСоставногоТипаXS");
+            TypeManager.RegisterAliasFor(type, "EnumerationXSComplexFinal");
+            TypeManager.RegisterAliasFor(enumValueType, "XSComplexFinal");
 
             EnumerationXSComplexFinal instance = new EnumerationXSComplexFinal(type, enumValueType);
-            instance.AddValue("Все", "All", new XSComplexFinal(instance, XmlSchemaDerivationMethod.All));
-            instance.AddValue("Ограничение", "Restriction", new XSComplexFinal(instance, XmlSchemaDerivationMethod.Restriction));
             instance.AddValue("Расширение", "Extension", new XSComplexFinal(instance, XmlSchemaDerivationMethod.Extension));
+            instance.AddValue("Ограничение", "Restriction", new XSComplexFinal(instance, XmlSchemaDerivationMethod.Restriction));
+            instance.AddValue("Все", "All", new XSComplexFinal(instance, XmlSchemaDerivationMethod.All));
 
             return instance;
         }

--- a/src/ScriptEngine.HostedScript/Library/XMLSchema/Enumerations/XSComponentType.cs
+++ b/src/ScriptEngine.HostedScript/Library/XMLSchema/Enumerations/XSComponentType.cs
@@ -7,104 +7,104 @@ at http://mozilla.org/MPL/2.0/.
 
 namespace ScriptEngine.HostedScript.Library.XMLSchema
 {
-    [EnumerationType("XSComponentType", "ТипКомпонентыXS")]
+    [EnumerationType("ТипКомпонентыXS", "XSComponentType")]
     public enum XSComponentType
     {
 
-        [EnumItem("Annotation", "Аннотация")]
+        [EnumItem("Аннотация", "Annotation")]
         Annotation,
 
-        [EnumItem("Include", "Включение")]
-        Include,
-
-        [EnumItem("ModelGroup", "ГруппаМодели")]
-        ModelGroup,
-
-        [EnumItem("Documentation", "Документация")]
-        Documentation,
-
-        [EnumItem("Import", "Импорт")]
-        Import,
-
-        [EnumItem("AppInfo", "ИнформацияПриложения")]
+        [EnumItem("ИнформацияПриложения", "AppInfo")]
         AppInfo,
 
-        [EnumItem("AttributeUse", "ИспользованиеАтрибута")]
-        AttributeUse,
+        [EnumItem("Документация", "Documentation")]
+        Documentation,
 
-        [EnumItem("MaxInclusiveFacet", "МаксимальноВключающийФасет")]
-        MaxInclusiveFacet,
-
-        [EnumItem("MaxExclusiveFacet", "МаксимальноИсключающийФасет")]
-        MaxExclusiveFacet,
-
-        [EnumItem("Wildcard", "Маска")]
-        Wildcard,
-
-        [EnumItem("MinInclusiveFacet", "МинимальноВключающийФасет")]
-        MinInclusiveFacet,
-
-        [EnumItem("MinExclusiveFacet", "МинимальноИсключающийФасет")]
-        MinExclusiveFacet,
-
-        [EnumItem("AttributeDeclaration", "ОбъявлениеАтрибута")]
-        AttributeDeclaration,
-
-        [EnumItem("NotationDeclaration", "ОбъявлениеНотации")]
-        NotationDeclaration,
-
-        [EnumItem("ElementDeclaration", "ОбъявлениеЭлемента")]
-        ElementDeclaration,
-
-        [EnumItem("XPathDefinition", "ОпределениеXPath")]
-        XPathDefinition,
-
-        [EnumItem("AttributeGroupDefinition", "ОпределениеГруппыАтрибутов")]
-        AttributeGroupDefinition,
-
-        [EnumItem("ModelGroupDefinition", "ОпределениеГруппыМодели")]
-        ModelGroupDefinition,
-
-        [EnumItem("IdentityConstraintDefinition", "ОпределениеОграниченияИдентичности")]
+        [EnumItem("ОпределениеОграниченияИдентичности", "IdentityConstraintDefinition")]
         IdentityConstraintDefinition,
 
-        [EnumItem("SimpleTypeDefinition", "ОпределениеПростогоТипа")]
+        [EnumItem("ОбъявлениеАтрибута", "AttributeDeclaration")]
+        AttributeDeclaration,
+
+        [EnumItem("ОбъявлениеЭлемента", "ElementDeclaration")]
+        ElementDeclaration,
+
+        [EnumItem("ОбъявлениеНотации", "NotationDeclaration")]
+        NotationDeclaration,
+
+        [EnumItem("ОпределениеПростогоТипа", "SimpleTypeDefinition")]
         SimpleTypeDefinition,
 
-        [EnumItem("ComplexTypeDefinition", "ОпределениеСоставногоТипа")]
+        [EnumItem("ОпределениеСоставногоТипа", "ComplexTypeDefinition")]
         ComplexTypeDefinition,
 
-        [EnumItem("Redefine", "Переопределение")]
-        Redefine,
+        [EnumItem("ОпределениеГруппыАтрибутов", "AttributeGroupDefinition")]
+        AttributeGroupDefinition,
 
-        [EnumItem("Schema", "Схема")]
-        Schema,
+        [EnumItem("ОпределениеГруппыМодели", "ModelGroupDefinition")]
+        ModelGroupDefinition,
 
-        [EnumItem("LengthFacet", "ФасетДлины")]
-        LengthFacet,
+        [EnumItem("Фрагмент", "Particle")]
+        Particle,
 
-        [EnumItem("FractionDigitsFacet", "ФасетКоличестваРазрядовДробнойЧасти")]
-        FractionDigitsFacet,
+        [EnumItem("ОпределениеXPath", "XPathDefinition")]
+        XPathDefinition,
 
-        [EnumItem("MaxLengthFacet", "ФасетМаксимальнойДлины")]
-        MaxLengthFacet,
-
-        [EnumItem("MinLengthFacet", "ФасетМинимальнойДлины")]
-        MinLengthFacet,
-
-        [EnumItem("PatternFacet", "ФасетОбразца")]
-        PatternFacet,
-
-        [EnumItem("TotalDigitsFacet", "ФасетОбщегоКоличестваРазрядов")]
+        [EnumItem("ФасетОбщегоКоличестваРазрядов", "TotalDigitsFacet")]
         TotalDigitsFacet,
 
-        [EnumItem("EnumerationFacet", "ФасетПеречисления")]
+        [EnumItem("ФасетКоличестваРазрядовДробнойЧасти", "FractionDigitsFacet")]
+        FractionDigitsFacet,
+
+        [EnumItem("ФасетДлины", "LengthFacet")]
+        LengthFacet,
+
+        [EnumItem("ФасетМинимальнойДлины", "MinLengthFacet")]
+        MinLengthFacet,
+
+        [EnumItem("ФасетМаксимальнойДлины", "MaxLengthFacet")]
+        MaxLengthFacet,
+
+        [EnumItem("МинимальноИсключающийФасет", "MinExclusiveFacet")]
+        MinExclusiveFacet,
+
+        [EnumItem("МинимальноВключающийФасет", "MinInclusiveFacet")]
+        MinInclusiveFacet,
+
+        [EnumItem("МаксимальноИсключающийФасет", "MaxExclusiveFacet")]
+        MaxExclusiveFacet,
+
+        [EnumItem("МаксимальноВключающийФасет", "MaxInclusiveFacet")]
+        MaxInclusiveFacet,
+
+        [EnumItem("ФасетПеречисления", "EnumerationFacet")]
         EnumerationFacet,
 
-        [EnumItem("WhitespaceFacet", "ФасетПробельныхСимволов")]
+        [EnumItem("ФасетОбразца", "PatternFacet")]
+        PatternFacet,
+
+        [EnumItem("ФасетПробельныхСимволов", "WhitespaceFacet")]
         WhitespaceFacet,
 
-        [EnumItem("Particle", "Фрагмент")]
-        Particle
+        [EnumItem("Импорт", "Import")]
+        Import,
+
+        [EnumItem("Переопределение", "Redefine")]
+        Redefine,
+
+        [EnumItem("Включение", "Include")]
+        Include,
+
+        [EnumItem("Маска", "Wildcard")]
+        Wildcard,
+
+        [EnumItem("ГруппаМодели", "ModelGroup")]
+        ModelGroup,
+
+        [EnumItem("ИспользованиеАтрибута", "AttributeUse")]
+        AttributeUse,
+
+        [EnumItem("Схема", "Schema")]
+        Schema
     }
 }

--- a/src/ScriptEngine.HostedScript/Library/XMLSchema/Enumerations/XSCompositor.cs
+++ b/src/ScriptEngine.HostedScript/Library/XMLSchema/Enumerations/XSCompositor.cs
@@ -12,28 +12,28 @@ namespace ScriptEngine.HostedScript.Library.XMLSchema
     /// Вид группы модели
     /// </summary>
     /// <see cref="XmlSchemaGroupBase"/>
-    [EnumerationType("XSCompositor", "ВидГруппыМоделиXS")]
+    [EnumerationType("ВидГруппыМоделиXS", "XSCompositor")]
     public enum XSCompositor
     {
         /// <summary>
         /// Требует наличия элементов группы без требования последовательности
         /// </summary>
         /// <see cref="XmlSchemaAll"/>
-        [EnumItem("All", "Все")]
+        [EnumItem("Все", "All")]
         All,
 
         /// <summary>
         /// Требует наличия только одного из элементов группы
         /// </summary>
         /// <see cref="XmlSchemaChoice"/>
-        [EnumItem("Choice", "Выбор")]
+        [EnumItem("Выбор", "Choice")]
         Choice,
 
         /// <summary>
         /// Требует чтобы элементы следовали в указанной последовательности
         /// </summary>
         /// <see cref="XmlSchemaSequence"/>
-        [EnumItem("Sequence", "Последовательность")]
+        [EnumItem("Последовательность", "Sequence")]
         Sequence
     }
 }

--- a/src/ScriptEngine.HostedScript/Library/XMLSchema/Enumerations/XSConstraint.cs
+++ b/src/ScriptEngine.HostedScript/Library/XMLSchema/Enumerations/XSConstraint.cs
@@ -10,19 +10,19 @@ namespace ScriptEngine.HostedScript.Library.XMLSchema
     /// <summary>
     /// Описывает варианты ограничения значения
     /// </summary>
-    [EnumerationType("XSConstraint", "ОграничениеЗначенияXS")]
+    [EnumerationType("ОграничениеЗначенияXS", "XSConstraint")]
     public enum XSConstraint
     {
         /// <summary>
         /// Используется ограничение по умолчанию
         /// </summary>
-        [EnumItem("Default", "ПоУмолчанию")]
+        [EnumItem("ПоУмолчанию", "Default")]
         Default,
 
         /// <summary>
         /// Используется фиксированное значение
         /// </summary>
-        [EnumItem("Fixed", "Фиксированное")]
+        [EnumItem("Фиксированное", "Fixed")]
         Fixed
     }
 }

--- a/src/ScriptEngine.HostedScript/Library/XMLSchema/Enumerations/XSContentModel.cs
+++ b/src/ScriptEngine.HostedScript/Library/XMLSchema/Enumerations/XSContentModel.cs
@@ -10,16 +10,16 @@ namespace ScriptEngine.HostedScript.Library.XMLSchema
     /// <summary>
     /// Определяет вид модели содержания.
     /// </summary>
-    [EnumerationType("XSContentModel", "МодельСодержимогоXS")]
+    [EnumerationType("МодельСодержимогоXS", "XSContentModel")]
     public enum XSContentModel
     {
-        [EnumItem("EmptyRef", "ПустаяСсылка")]
-        EmptyRef,
-
-        [EnumItem("Simple", "Простая")]
+        [EnumItem("Простая", "Simple" )]
         Simple,
 
-        [EnumItem("Complex", "Составная")]
-        Complex
+        [EnumItem("Составная", "Complex")]
+        Complex,
+
+        [EnumItem("ПустаяСсылка", "EmptyRef")]
+        EmptyRef
     }
 }

--- a/src/ScriptEngine.HostedScript/Library/XMLSchema/Enumerations/XSDerivationMethod.cs
+++ b/src/ScriptEngine.HostedScript/Library/XMLSchema/Enumerations/XSDerivationMethod.cs
@@ -7,16 +7,16 @@ at http://mozilla.org/MPL/2.0/.
 
 namespace ScriptEngine.HostedScript.Library.XMLSchema
 {
-    [EnumerationType("XSDerivationMethod", "МетодНаследованияXS")]
+    [EnumerationType("МетодНаследованияXS", "XSDerivationMethod")]
     public enum XSDerivationMethod
     {
-        [EnumItem("EmptyRef", "ПустаяСсылка")]
-        EmptyRef,
+        [EnumItem("Расширение", "Extension")]
+        Extension,
 
-        [EnumItem("Restriction", "Ограничение")]
+        [EnumItem("Ограничение", "Restriction")]
         Restriction,
 
-        [EnumItem("Extension", "Расширение")]
-        Extension
+        [EnumItem("ПустаяСсылка", "EmptyRef")]
+        EmptyRef
     }
 }

--- a/src/ScriptEngine.HostedScript/Library/XMLSchema/Enumerations/XSDisallowedSubstitutions.cs
+++ b/src/ScriptEngine.HostedScript/Library/XMLSchema/Enumerations/XSDisallowedSubstitutions.cs
@@ -64,18 +64,18 @@ namespace ScriptEngine.HostedScript.Library.XMLSchema
         public static EnumerationXSDisallowedSubstitutions CreateInstance()
         {
 
-            TypeDescriptor type = TypeManager.RegisterType("EnumerationXSDisallowedSubstitutions", typeof(EnumerationXSDisallowedSubstitutions));
-            TypeDescriptor enumValueType = TypeManager.RegisterType("XSDisallowedSubstitutions",   typeof(XSDisallowedSubstitutions));
+            TypeDescriptor type = TypeManager.RegisterType("ПеречислениеНедопустимыеПодстановкиXS", typeof(EnumerationXSDisallowedSubstitutions));
+            TypeDescriptor enumValueType = TypeManager.RegisterType("НедопустимыеПодстановкиXS",   typeof(XSDisallowedSubstitutions));
 
-            TypeManager.RegisterAliasFor(type, "ПеречислениеНедопустимыеПодстановкиXS"); 
-            TypeManager.RegisterAliasFor(enumValueType, "НедопустимыеПодстановкиXS");
+            TypeManager.RegisterAliasFor(type, "EnumerationXSDisallowedSubstitutions"); 
+            TypeManager.RegisterAliasFor(enumValueType, "XSDisallowedSubstitutions");
 
             EnumerationXSDisallowedSubstitutions instance = new EnumerationXSDisallowedSubstitutions(type, enumValueType);
 
-            instance.AddValue("Все", "All", instance._valuesCache[XmlSchemaDerivationMethod.All]);
+            instance.AddValue("Расширение", "Extension", instance._valuesCache[XmlSchemaDerivationMethod.Extension]);
             instance.AddValue("Ограничение", "Restriction", instance._valuesCache[XmlSchemaDerivationMethod.Restriction]);
             instance.AddValue("Подстановка", "Substitution", instance._valuesCache[XmlSchemaDerivationMethod.Substitution]);
-            instance.AddValue("Расширение", "Extension", instance._valuesCache[XmlSchemaDerivationMethod.Extension]);
+            instance.AddValue("Все", "All", instance._valuesCache[XmlSchemaDerivationMethod.All]);
 
             return instance;
         }

--- a/src/ScriptEngine.HostedScript/Library/XMLSchema/Enumerations/XSForm.cs
+++ b/src/ScriptEngine.HostedScript/Library/XMLSchema/Enumerations/XSForm.cs
@@ -55,11 +55,11 @@ namespace ScriptEngine.HostedScript.Library.XMLSchema
         public static EnumerationXSForm CreateInstance()
         {
  
-            TypeDescriptor type          = TypeManager.RegisterType("EnumerationXSForm",  typeof(EnumerationXSForm));
-            TypeDescriptor enumValueType = TypeManager.RegisterType("XSForm",             typeof(XSForm));
+            TypeDescriptor type          = TypeManager.RegisterType("ПеречислениеФормаПредставленияXS", typeof(EnumerationXSForm));
+            TypeDescriptor enumValueType = TypeManager.RegisterType("ФормаПредставленияXS", typeof(XSForm));
 
-            TypeManager.RegisterAliasFor(type,          "ПеречислениеФормаПредставленияXS"); 
-            TypeManager.RegisterAliasFor(enumValueType, "ФормаПредставленияXS");
+            TypeManager.RegisterAliasFor(type, "EnumerationXSForm"); 
+            TypeManager.RegisterAliasFor(enumValueType, "XSForm");
 
             EnumerationXSForm instance = new EnumerationXSForm(type, enumValueType);
 

--- a/src/ScriptEngine.HostedScript/Library/XMLSchema/Enumerations/XSIdentityConstraintCategory.cs
+++ b/src/ScriptEngine.HostedScript/Library/XMLSchema/Enumerations/XSIdentityConstraintCategory.cs
@@ -13,28 +13,28 @@ namespace ScriptEngine.HostedScript.Library.XMLSchema
     /// Типы ограничения идентичности.
     /// </summary>
     /// <see cref="XSIdentityConstraintDefinition"/>
-    [EnumerationType("XSIdentityConstraintCategory", "КатегорияОграниченияИдентичностиXS")]
+    [EnumerationType("КатегорияОграниченияИдентичностиXS", "XSIdentityConstraintCategory")]
     public enum XSIdentityConstraintCategory
     {
         /// <summary>
         /// Ограничение идентичности по ключу
         /// </summary>
         /// <see cref="XmlSchemaKey"/>
-        [EnumItem("Key", "Ключ")]
+        [EnumItem("Ключ", "Key")]
         Key,
 
         /// <summary>
         /// Ограничение идентичности по ссылке
         /// </summary>
         /// <see cref="XmlSchemaKey"/>
-        [EnumItem("KeyRef", "СсылкаНаКлюч")]
+        [EnumItem("СсылкаНаКлюч", "KeyRef")]
         KeyRef,
 
         /// <summary>
         /// Ограничение идентичности по опредению уникальности
         /// </summary>
         /// <see cref="XmlSchemaUnique"/>
-        [EnumItem("Unique", "Уникальность")]
+        [EnumItem("Уникальность", "Unique")]
         Unique
     }
 }

--- a/src/ScriptEngine.HostedScript/Library/XMLSchema/Enumerations/XSNamespaceConstraintCategory.cs
+++ b/src/ScriptEngine.HostedScript/Library/XMLSchema/Enumerations/XSNamespaceConstraintCategory.cs
@@ -7,19 +7,19 @@ at http://mozilla.org/MPL/2.0/.
 
 namespace ScriptEngine.HostedScript.Library.XMLSchema
 {
-    [EnumerationType("XSNamespaceConstraintCategory", "КатегорияОграниченияПространствИменXS")]
+    [EnumerationType("КатегорияОграниченияПространствИменXS", "XSNamespaceConstraintCategory")]
     public enum XSNamespaceConstraintCategory
     {
-        [EnumItem("EmptyRef", "ПустаяСсылка")]
-        EmptyRef,
-
-        [EnumItem("Not", "Кроме")]
-        Not,
-
-        [EnumItem("Any", "Любое")]
+        [EnumItem("Любое", "Any")]
         Any,
 
-        [EnumItem("Set", "Набор")]
-        Set
+        [EnumItem("Кроме", "Not")]
+        Not,
+
+        [EnumItem("Набор", "Set")]
+        Set,
+
+        [EnumItem("ПустаяСсылка", "EmptyRef")]
+        EmptyRef
     }
 }

--- a/src/ScriptEngine.HostedScript/Library/XMLSchema/Enumerations/XSProcessContents.cs
+++ b/src/ScriptEngine.HostedScript/Library/XMLSchema/Enumerations/XSProcessContents.cs
@@ -9,19 +9,19 @@ using System.Xml.Schema;
 
 namespace ScriptEngine.HostedScript.Library.XMLSchema
 {
-    [EnumerationType("XSProcessContents", "ОбработкаСодержимогоXS")]
+    [EnumerationType("ОбработкаСодержимогоXS", "XSProcessContents")]
     public enum XSProcessContents
     {
-        [EnumItem("EmptyRef", "ПустаяСсылка")]
-        EmptyRef = XmlSchemaContentProcessing.None,
+        [EnumItem("Строгая", "Strict")]
+        Strict = XmlSchemaContentProcessing.Strict,
 
-        [EnumItem("Skip", "Пропустить")]
+        [EnumItem("Пропустить", "Skip")]
         Skip = XmlSchemaContentProcessing.Skip,
 
-        [EnumItem("Lax", "Слабая")]
+        [EnumItem("Слабая", "Lax")]
         Lax = XmlSchemaContentProcessing.Lax,
 
-        [EnumItem("Strict", "Строгая")]
-        Strict = XmlSchemaContentProcessing.Strict
+        [EnumItem("ПустаяСсылка", "EmptyRef")]
+        EmptyRef = XmlSchemaContentProcessing.None
     }
 }

--- a/src/ScriptEngine.HostedScript/Library/XMLSchema/Enumerations/XSProhibitedSubstitutions.cs
+++ b/src/ScriptEngine.HostedScript/Library/XMLSchema/Enumerations/XSProhibitedSubstitutions.cs
@@ -63,17 +63,17 @@ namespace ScriptEngine.HostedScript.Library.XMLSchema
         public static EnumerationXSProhibitedSubstitutions CreateInstance()
         {
 
-            TypeDescriptor type = TypeManager.RegisterType("EnumerationXSProhibitedSubstitutions", typeof(EnumerationXSProhibitedSubstitutions));
-            TypeDescriptor enumValueType = TypeManager.RegisterType("XSProhibitedSubstitutions", typeof(XSProhibitedSubstitutions));
+            TypeDescriptor type = TypeManager.RegisterType("ПеречислениеЗапрещенныеПодстановкиXS", typeof(EnumerationXSProhibitedSubstitutions));
+            TypeDescriptor enumValueType = TypeManager.RegisterType("ЗапрещенныеПодстановкиXS", typeof(XSProhibitedSubstitutions));
 
-            TypeManager.RegisterAliasFor(type, "ПеречислениеЗапрещенныеПодстановкиXS");
-            TypeManager.RegisterAliasFor(enumValueType, "ЗапрещенныеПодстановкиXS");
+            TypeManager.RegisterAliasFor(type, "EnumerationXSProhibitedSubstitutions");
+            TypeManager.RegisterAliasFor(enumValueType, "XSProhibitedSubstitutions");
 
             EnumerationXSProhibitedSubstitutions instance = new EnumerationXSProhibitedSubstitutions(type, enumValueType);
 
-            instance.AddValue("Все", "All", instance._valuesCache[XmlSchemaDerivationMethod.All]);
-            instance.AddValue("Ограничение", "Restriction", instance._valuesCache[XmlSchemaDerivationMethod.Restriction]);
             instance.AddValue("Расширение", "Extension", instance._valuesCache[XmlSchemaDerivationMethod.Extension]);
+            instance.AddValue("Ограничение", "Restriction", instance._valuesCache[XmlSchemaDerivationMethod.Restriction]);
+            instance.AddValue("Все", "All", instance._valuesCache[XmlSchemaDerivationMethod.All]);
 
             return instance;
         }

--- a/src/ScriptEngine.HostedScript/Library/XMLSchema/Enumerations/XSSchemaFinal.cs
+++ b/src/ScriptEngine.HostedScript/Library/XMLSchema/Enumerations/XSSchemaFinal.cs
@@ -65,20 +65,20 @@ namespace ScriptEngine.HostedScript.Library.XMLSchema
         public static EnumerationXSSchemaFinal CreateInstance()
         {
 
-            TypeDescriptor type = TypeManager.RegisterType("EnumerationXSSchemaFinal", typeof(EnumerationXSSchemaFinal));
-            TypeDescriptor enumValueType = TypeManager.RegisterType("XSSchemaFinal", typeof(XSSchemaFinal));
+            TypeDescriptor type = TypeManager.RegisterType("ПеречислениеЗавершенностьСхемыXS", typeof(EnumerationXSSchemaFinal));
+            TypeDescriptor enumValueType = TypeManager.RegisterType("ЗавершенностьСхемыXS", typeof(XSSchemaFinal));
 
-            TypeManager.RegisterAliasFor(type, "ПеречислениеЗавершенностьСхемыXS");
-            TypeManager.RegisterAliasFor(enumValueType, "ЗавершенностьСхемыXS");
+            TypeManager.RegisterAliasFor(type, "EnumerationXSSchemaFinal");
+            TypeManager.RegisterAliasFor(enumValueType, "XSSchemaFinal");
 
             EnumerationXSSchemaFinal instance = new EnumerationXSSchemaFinal(type, enumValueType);
 
-            instance.AddValue("Все", "All", instance._valuesCache[XmlSchemaDerivationMethod.All]);
-            instance.AddValue("Объединение", "Union", instance._valuesCache[XmlSchemaDerivationMethod.Union]);
-            instance.AddValue("Ограничение", "Restriction", instance._valuesCache[XmlSchemaDerivationMethod.Restriction]);
-            instance.AddValue("Расширение", "Extension", instance._valuesCache[XmlSchemaDerivationMethod.Extension]);
             instance.AddValue("Список", "List", instance._valuesCache[XmlSchemaDerivationMethod.List]);
- 
+            instance.AddValue("Объединение", "Union", instance._valuesCache[XmlSchemaDerivationMethod.Union]);
+            instance.AddValue("Расширение", "Extension", instance._valuesCache[XmlSchemaDerivationMethod.Extension]);
+            instance.AddValue("Ограничение", "Restriction", instance._valuesCache[XmlSchemaDerivationMethod.Restriction]);
+            instance.AddValue("Все", "All", instance._valuesCache[XmlSchemaDerivationMethod.All]);
+
             return instance;
         }
     }

--- a/src/ScriptEngine.HostedScript/Library/XMLSchema/Enumerations/XSSimpleFinal.cs
+++ b/src/ScriptEngine.HostedScript/Library/XMLSchema/Enumerations/XSSimpleFinal.cs
@@ -62,18 +62,18 @@ namespace ScriptEngine.HostedScript.Library.XMLSchema
         public static EnumerationXSSimpleFinal CreateInstance()
         {
 
-            TypeDescriptor type = TypeManager.RegisterType("EnumerationXSSimpleFinal", typeof(EnumerationXSSimpleFinal));
-            TypeDescriptor enumValueType = TypeManager.RegisterType("XSSimpleFinal", typeof(XSSimpleFinal));
+            TypeDescriptor type = TypeManager.RegisterType("ПеречислениеЗавершенностьПростогоТипаXS", typeof(EnumerationXSSimpleFinal));
+            TypeDescriptor enumValueType = TypeManager.RegisterType("ЗавершенностьПростогоТипаXS", typeof(XSSimpleFinal));
 
-            TypeManager.RegisterAliasFor(type, "ПеречислениеЗавершенностьПростогоТипаXS");
-            TypeManager.RegisterAliasFor(enumValueType, "ЗавершенностьПростогоТипаXS");
+            TypeManager.RegisterAliasFor(type, "EnumerationXSSimpleFinal");
+            TypeManager.RegisterAliasFor(enumValueType, "XSSimpleFinal");
 
             EnumerationXSSimpleFinal instance = new EnumerationXSSimpleFinal(type, enumValueType);
 
-            instance.AddValue("Все", "All", instance._valuesCache[XmlSchemaDerivationMethod.All]);
+            instance.AddValue("Список", "List", instance._valuesCache[XmlSchemaDerivationMethod.List]);
             instance.AddValue("Объединение", "Union", instance._valuesCache[XmlSchemaDerivationMethod.Union]);
             instance.AddValue("Ограничение", "Restriction", instance._valuesCache[XmlSchemaDerivationMethod.Restriction]);
-            instance.AddValue("Список", "List", instance._valuesCache[XmlSchemaDerivationMethod.List]);
+            instance.AddValue("Все", "All", instance._valuesCache[XmlSchemaDerivationMethod.All]);
 
             return instance;
         }

--- a/src/ScriptEngine.HostedScript/Library/XMLSchema/Enumerations/XSSimpleTypeVariety.cs
+++ b/src/ScriptEngine.HostedScript/Library/XMLSchema/Enumerations/XSSimpleTypeVariety.cs
@@ -7,16 +7,16 @@ at http://mozilla.org/MPL/2.0/.
 
 namespace ScriptEngine.HostedScript.Library.XMLSchema
 {
-    [EnumerationType("XSSimpleTypeVariety", "ВариантПростогоТипаXS")]
+    [EnumerationType("ВариантПростогоТипаXS", "XSSimpleTypeVariety")]
     public enum XSSimpleTypeVariety
     {
-        [EnumItem("Atomic", "Атомарная")]
+        [EnumItem("Атомарная", "Atomic")]
         Atomic,
 
-        [EnumItem("Union", "Объединение")]
-        Union,
+        [EnumItem("Список", "List")]
+        List,
 
-        [EnumItem("List", "Список")]
-        List
+        [EnumItem("Объединение", "Union")]
+        Union,
     }
 }

--- a/src/ScriptEngine.HostedScript/Library/XMLSchema/Enumerations/XSSubstitutionGroupExclusions.cs
+++ b/src/ScriptEngine.HostedScript/Library/XMLSchema/Enumerations/XSSubstitutionGroupExclusions.cs
@@ -63,17 +63,17 @@ namespace ScriptEngine.HostedScript.Library.XMLSchema
         public static EnumerationXSSubstitutionGroupExclusions CreateInstance()
         {
 
-            TypeDescriptor type = TypeManager.RegisterType("EnumerationXSSubstitutionGroupExclusions", typeof(EnumerationXSSubstitutionGroupExclusions));
-            TypeDescriptor enumValueType = TypeManager.RegisterType("XSSubstitutionGroupExclusions", typeof(XSSubstitutionGroupExclusions));
+            TypeDescriptor type = TypeManager.RegisterType("ПеречислениеИсключенияГруппПодстановкиXS", typeof(EnumerationXSSubstitutionGroupExclusions));
+            TypeDescriptor enumValueType = TypeManager.RegisterType("ИсключенияГруппПодстановкиXS", typeof(XSSubstitutionGroupExclusions));
 
-            TypeManager.RegisterAliasFor(type, "ПеречислениеИсключенияГруппПодстановкиXS");
-            TypeManager.RegisterAliasFor(enumValueType, "ИсключенияГруппПодстановкиXS");
+            TypeManager.RegisterAliasFor(type, "EnumerationXSSubstitutionGroupExclusions");
+            TypeManager.RegisterAliasFor(enumValueType, "XSSubstitutionGroupExclusions");
 
             EnumerationXSSubstitutionGroupExclusions instance = new EnumerationXSSubstitutionGroupExclusions(type, enumValueType);
 
-            instance.AddValue("Все", "All", instance._valuesCache[XmlSchemaDerivationMethod.All]);
-            instance.AddValue("Ограничение", "Restriction", instance._valuesCache[XmlSchemaDerivationMethod.Restriction]);
             instance.AddValue("Расширение", "Extension", instance._valuesCache[XmlSchemaDerivationMethod.Extension]);
+            instance.AddValue("Ограничение", "Restriction", instance._valuesCache[XmlSchemaDerivationMethod.Restriction]);
+            instance.AddValue("Все", "All", instance._valuesCache[XmlSchemaDerivationMethod.All]);
 
             return instance;
         }

--- a/src/ScriptEngine.HostedScript/Library/XMLSchema/Enumerations/XSWhitespaceHandling.cs
+++ b/src/ScriptEngine.HostedScript/Library/XMLSchema/Enumerations/XSWhitespaceHandling.cs
@@ -7,16 +7,16 @@ at http://mozilla.org/MPL/2.0/.
 
 namespace ScriptEngine.HostedScript.Library.XMLSchema
 {
-    [EnumerationType("XSWhitespaceHandling", "ОбработкаПробельныхСимволовXS")]
+    [EnumerationType("ОбработкаПробельныхСимволовXS", "XSWhitespaceHandling")]
     public enum XSWhitespaceHandling
     {
-        [EnumItem("Replace", "Заменять")]
+        [EnumItem("Сохранять", "Preserve")]
+        Preserve,
+
+        [EnumItem("Заменять", "Replace")]
         Replace,
 
-        [EnumItem("Collapse", "Сворачивать")]
-        Collapse,
-
-        [EnumItem("Preserve", "Сохранять")]
-        Preserve
+        [EnumItem("Сворачивать", "Collapse")]
+        Collapse
     }
 }

--- a/src/ScriptEngine.HostedScript/Library/XMLSchema/Enumerations/XSXPathVariety.cs
+++ b/src/ScriptEngine.HostedScript/Library/XMLSchema/Enumerations/XSXPathVariety.cs
@@ -11,19 +11,19 @@ namespace ScriptEngine.HostedScript.Library.XMLSchema
     /// Содержит варианты использования выражения XPath.
     /// </summary>
     /// <see cref="XSXPathDefinition"/>
-    [EnumerationType("XSXPathVariety", "ВариантXPathXS")]
+    [EnumerationType("ВариантXPathXS", "XSXPathVariety")]
     public enum XSXPathVariety
     {
         /// <summary>
-        /// Используется в качестве поля
-        /// </summary>
-        [EnumItem("Field", "Поле")]
-        Field,
-  
-        /// <summary>
         /// Используется в качестве селектора
         /// </summary>
-        [EnumItem("Selector", "Селектор")]
-        Selector
+        [EnumItem("Селектор","Selector")]
+        Selector,
+
+        /// <summary>
+        /// Используется в качестве поля
+        /// </summary>
+        [EnumItem("Поле","Field")]
+        Field
     }
 }

--- a/src/ScriptEngine.HostedScript/Library/Xml/XMLTypeAssignment.cs
+++ b/src/ScriptEngine.HostedScript/Library/Xml/XMLTypeAssignment.cs
@@ -7,13 +7,13 @@ at http://mozilla.org/MPL/2.0/.
 
 namespace ScriptEngine.HostedScript.Library.Xml
 {
-    [EnumerationType("XMLTypeAssignment", "НазначениеТипаXML")]
+    [EnumerationType("НазначениеТипаXML", "XMLTypeAssignment")]
     public enum XMLTypeAssignment
     {
-        [EnumItem("Implicit", "Неявное")]
-        Implicit,
+        [EnumItem("Явное", "Explicit")]
+        Explicit,
 
-        [EnumItem("Explicit", "Явное")]
-        Explicit
+        [EnumItem("Неявное", "Implicit")]
+        Implicit
     }
 }

--- a/src/ScriptEngine.HostedScript/Library/Xml/XmlNodeTypeEnum.cs
+++ b/src/ScriptEngine.HostedScript/Library/Xml/XmlNodeTypeEnum.cs
@@ -48,23 +48,26 @@ namespace ScriptEngine.HostedScript.Library.Xml
             var type = TypeManager.RegisterType("ПеречислениеТипУзлаXML", typeof(XmlNodeTypeEnum));
             var enumValueType = TypeManager.RegisterType("ТипУзлаXML", typeof(CLREnumValueWrapper<XmlNodeType>));
 
+            TypeManager.RegisterAliasFor(type, "EnumerationXMLNodeType");
+            TypeManager.RegisterAliasFor(enumValueType, "XMLNodeType");
+
             instance = new XmlNodeTypeEnum(type, enumValueType);
 
-            instance.AddValue("Атрибут", "Attribute", new CLREnumValueWrapper<XmlNodeType>(instance, XmlNodeType.Attribute));
-            instance.AddValue("ИнструкцияОбработки", "ProcessingInstruction", new CLREnumValueWrapper<XmlNodeType>(instance, XmlNodeType.ProcessingInstruction));
-            instance.AddValue("Комментарий", "Comment", new CLREnumValueWrapper<XmlNodeType>(instance, XmlNodeType.Comment));
-            instance.AddValue("КонецСущности", "EndEntity", new CLREnumValueWrapper<XmlNodeType>(instance, XmlNodeType.EndEntity));
-            instance.AddValue("КонецЭлемента", "EndElement", new CLREnumValueWrapper<XmlNodeType>(instance, XmlNodeType.EndElement));
-            instance.AddValue("НачалоЭлемента", "StartElement", new CLREnumValueWrapper<XmlNodeType>(instance, XmlNodeType.Element));
             instance.AddValue("Ничего", "None", new CLREnumValueWrapper<XmlNodeType>(instance, XmlNodeType.None));
-            instance.AddValue("Нотация", "Notation", new CLREnumValueWrapper<XmlNodeType>(instance, XmlNodeType.Notation));
-            instance.AddValue("ОбъявлениеXML", "XMLDeclaration", new CLREnumValueWrapper<XmlNodeType>(instance, XmlNodeType.XmlDeclaration));
-            instance.AddValue("ОпределениеТипаДокумента", "DocumentTypeDefinition", new CLREnumValueWrapper<XmlNodeType>(instance, XmlNodeType.DocumentType));
-            instance.AddValue("ПробельныеСимволы", "Whitespace", new CLREnumValueWrapper<XmlNodeType>(instance, XmlNodeType.Whitespace));
+            instance.AddValue("Атрибут", "Attribute", new CLREnumValueWrapper<XmlNodeType>(instance, XmlNodeType.Attribute));
             instance.AddValue("СекцияCDATA", "CDATASection", new CLREnumValueWrapper<XmlNodeType>(instance, XmlNodeType.CDATA));
-            instance.AddValue("СсылкаНаСущность", "EntityReference", new CLREnumValueWrapper<XmlNodeType>(instance, XmlNodeType.EntityReference));
+            instance.AddValue("Комментарий", "Comment", new CLREnumValueWrapper<XmlNodeType>(instance, XmlNodeType.Comment));
+            instance.AddValue("ОпределениеТипаДокумента", "DocumentTypeDefinition", new CLREnumValueWrapper<XmlNodeType>(instance, XmlNodeType.DocumentType));
+            instance.AddValue("НачалоЭлемента", "StartElement", new CLREnumValueWrapper<XmlNodeType>(instance, XmlNodeType.Element));
+            instance.AddValue("КонецЭлемента", "EndElement", new CLREnumValueWrapper<XmlNodeType>(instance, XmlNodeType.EndElement));
+            instance.AddValue("КонецСущности", "EndEntity", new CLREnumValueWrapper<XmlNodeType>(instance, XmlNodeType.EndEntity));
             instance.AddValue("Сущность", "Entity", new CLREnumValueWrapper<XmlNodeType>(instance, XmlNodeType.Entity));
+            instance.AddValue("СсылкаНаСущность", "EntityReference", new CLREnumValueWrapper<XmlNodeType>(instance, XmlNodeType.EntityReference));
+            instance.AddValue("Нотация", "Notation", new CLREnumValueWrapper<XmlNodeType>(instance, XmlNodeType.Notation));
+            instance.AddValue("ИнструкцияОбработки", "ProcessingInstruction", new CLREnumValueWrapper<XmlNodeType>(instance, XmlNodeType.ProcessingInstruction));
             instance.AddValue("Текст", "Text", new CLREnumValueWrapper<XmlNodeType>(instance, XmlNodeType.Text));
+            instance.AddValue("ПробельныеСимволы", "Whitespace", new CLREnumValueWrapper<XmlNodeType>(instance, XmlNodeType.Whitespace));
+            instance.AddValue("ОбъявлениеXML", "XMLDeclaration", new CLREnumValueWrapper<XmlNodeType>(instance, XmlNodeType.XmlDeclaration));
 
             return instance;
         }

--- a/src/ScriptEngine.HostedScript/Library/Zip/FileNamesEncodingInZipFile.cs
+++ b/src/ScriptEngine.HostedScript/Library/Zip/FileNamesEncodingInZipFile.cs
@@ -12,11 +12,11 @@ namespace ScriptEngine.HostedScript.Library.Zip
     {
         [EnumItem("Авто")]
         Auto,
-        
+
+        [EnumItem("КодировкаОСДополнительноUTF8", "OSEncodingWithUTF8")]
+        OsEncodingWithUtf8,
+
         [EnumItem("UTF8")]
-        Utf8,
-        
-        [EnumItem("КодировкаОСДополнительноUTF8","OSEncodingWithUTF8")]
-        OsEncodingWithUtf8
+        Utf8
     }
 }

--- a/src/ScriptEngine.HostedScript/Library/Zip/ZIPSubDirProcessingModeEnum.cs
+++ b/src/ScriptEngine.HostedScript/Library/Zip/ZIPSubDirProcessingModeEnum.cs
@@ -12,31 +12,19 @@ namespace ScriptEngine.HostedScript.Library.Zip
     [SystemEnum("РежимОбработкиПодкаталоговZIP", "ZIPSubDirProcessingMode")]
     public class ZIPSubDirProcessingModeEnum : EnumerationContext
     {
-        private const string EV_DONT_RECURSE = "НеОбрабатывать";
         private const string EV_RECURSE = "ОбрабатыватьРекурсивно";
+        private const string EV_DONT_RECURSE = "НеОбрабатывать";
 
         private ZIPSubDirProcessingModeEnum(TypeDescriptor typeRepresentation, TypeDescriptor valuesType)
             : base(typeRepresentation, valuesType)
         {
         }
 
-        [EnumValue(EV_DONT_RECURSE, "DontProcess")]
-        public EnumerationValue DontRecurse
-        {
-            get
-            {
-                return this[EV_DONT_RECURSE];
-            }
-        }
-
         [EnumValue(EV_RECURSE, "ProcessRecursively")]
-        public EnumerationValue Recurse
-        {
-            get
-            {
-                return this[EV_RECURSE];
-            }
-        }
+        public EnumerationValue Recurse => this[EV_RECURSE];
+
+        [EnumValue(EV_DONT_RECURSE, "DontProcess")]
+        public EnumerationValue DontRecurse => this[EV_DONT_RECURSE];
 
         public static ZIPSubDirProcessingModeEnum CreateInstance()
         {

--- a/src/ScriptEngine.HostedScript/Library/Zip/ZipCompressionLevelEnum.cs
+++ b/src/ScriptEngine.HostedScript/Library/Zip/ZipCompressionLevelEnum.cs
@@ -22,31 +22,13 @@ namespace ScriptEngine.HostedScript.Library.Zip
         }
         
         [EnumValue(EV_MINIMAL_NAME, "Minimum")]
-        public EnumerationValue Minimal
-        {
-            get
-            {
-                return this[EV_MINIMAL_NAME];
-            }
-        }
+        public EnumerationValue Minimal => this[EV_MINIMAL_NAME];
 
         [EnumValue(EV_OPTIMAL_NAME, "Optimal")]
-        public EnumerationValue Optimal
-        {
-            get
-            {
-                return this[EV_OPTIMAL_NAME];
-            }
-        }
+        public EnumerationValue Optimal => this[EV_OPTIMAL_NAME];
 
         [EnumValue(EV_MAXIMAL_NAME, "Maximum")]
-        public EnumerationValue Maximal
-        {
-            get
-            {
-                return this[EV_MAXIMAL_NAME];
-            }
-        }
+        public EnumerationValue Maximal => this[EV_MAXIMAL_NAME];
 
         public static ZipCompressionLevelEnum CreateInstance()
         {

--- a/src/ScriptEngine.HostedScript/Library/Zip/ZipCompressionMethodEnum.cs
+++ b/src/ScriptEngine.HostedScript/Library/Zip/ZipCompressionMethodEnum.cs
@@ -21,22 +21,10 @@ namespace ScriptEngine.HostedScript.Library.Zip
         }
         
         [EnumValue(EV_COPY_NAME, "Copy")]
-        public EnumerationValue Copy
-        {
-            get
-            {
-                return this[EV_COPY_NAME];
-            }
-        }
+        public EnumerationValue Copy => this[EV_COPY_NAME];
 
         [EnumValue(EV_DEFLATE_NAME, "Deflate")]
-        public EnumerationValue Deflate
-        {
-            get
-            {
-                return this[EV_DEFLATE_NAME];
-            }
-        }
+        public EnumerationValue Deflate => this[EV_DEFLATE_NAME];
 
         public static ZipCompressionMethodEnum CreateInstance()
         {

--- a/src/ScriptEngine.HostedScript/Library/Zip/ZipEncryptionMethodEnum.cs
+++ b/src/ScriptEngine.HostedScript/Library/Zip/ZipEncryptionMethodEnum.cs
@@ -12,51 +12,27 @@ namespace ScriptEngine.HostedScript.Library.Zip
     [SystemEnum("МетодШифрованияZIP", "ZIPEncryptionMethod")]
     public class ZipEncryptionMethodEnum : EnumerationContext
     {
+        private const string EV_ZIP20 = "Zip20";
         private const string EV_AES128 = "AES128";
         private const string EV_AES192 = "AES192";
         private const string EV_AES256 = "AES256";
-        private const string EV_ZIP20 = "Zip20";
 
         private ZipEncryptionMethodEnum(TypeDescriptor typeRepresentation, TypeDescriptor valuesType)
             : base(typeRepresentation, valuesType)
         {
         }
 
+        [EnumValue(EV_ZIP20)]
+        public EnumerationValue Zip20 => this[EV_ZIP20];
+
         [EnumValue(EV_AES128)]
-        public EnumerationValue Aes128
-        {
-            get
-            {
-                return this[EV_AES128];
-            }
-        }
+        public EnumerationValue Aes128 => this[EV_AES128];
 
         [EnumValue(EV_AES192)]
-        public EnumerationValue Aes192
-        {
-            get
-            {
-                return this[EV_AES192];
-            }
-        }
+        public EnumerationValue Aes192 => this[EV_AES192];
 
         [EnumValue(EV_AES256)]
-        public EnumerationValue Aes256
-        {
-            get
-            {
-                return this[EV_AES256];
-            }
-        }
-
-        [EnumValue(EV_ZIP20)]
-        public EnumerationValue Zip20
-        {
-            get
-            {
-                return this[EV_ZIP20];
-            }
-        }
+        public EnumerationValue Aes256 => this[EV_AES256];
 
         public static ZipEncryptionMethodEnum CreateInstance()
         {

--- a/src/ScriptEngine.HostedScript/Library/Zip/ZipRestoreFilePathsModeEnum.cs
+++ b/src/ScriptEngine.HostedScript/Library/Zip/ZipRestoreFilePathsModeEnum.cs
@@ -21,22 +21,10 @@ namespace ScriptEngine.HostedScript.Library.Zip
         }
 
         [EnumValue(RESTORE_PATHS_NAME, "Restore")]
-        public EnumerationValue Restore
-        {
-            get
-            {
-                return this[RESTORE_PATHS_NAME];
-            }
-        }
+        public EnumerationValue Restore => this[RESTORE_PATHS_NAME];
 
         [EnumValue(DONT_RESTORE_PATHS_NAME, "DontRestore")]
-        public EnumerationValue DoNotRestore
-        {
-            get
-            {
-                return this[DONT_RESTORE_PATHS_NAME];
-            }
-        }
+        public EnumerationValue DoNotRestore => this[DONT_RESTORE_PATHS_NAME];
 
         public static ZipRestoreFilePathsModeEnum CreateInstance()
         {

--- a/src/ScriptEngine.HostedScript/Library/Zip/ZipStorePathModeEnum.cs
+++ b/src/ScriptEngine.HostedScript/Library/Zip/ZipStorePathModeEnum.cs
@@ -12,9 +12,9 @@ namespace ScriptEngine.HostedScript.Library.Zip
     [SystemEnum("РежимСохраненияПутейZIP", "ZIPStorePathsMode")]
     public class ZipStorePathModeEnum : EnumerationContext
     {
-        const string DONT_SAVE = "НеСохранятьПути";
-        const string SAVE_RELATIVE = "СохранятьОтносительныеПути";
         const string SAVE_FULL = "СохранятьПолныеПути";
+        const string SAVE_RELATIVE = "СохранятьОтносительныеПути";
+        const string DONT_SAVE = "НеСохранятьПути";
 
         public ZipStorePathModeEnum(TypeDescriptor typeRepresentation, TypeDescriptor valuesType)
             : base(typeRepresentation, valuesType)
@@ -22,32 +22,14 @@ namespace ScriptEngine.HostedScript.Library.Zip
 
         }
 
-        [EnumValue(DONT_SAVE, "DontStorePath")]
-        public EnumerationValue DontStorePath
-        {
-            get
-            {
-                return this[DONT_SAVE];
-            }
-        }
+        [EnumValue(SAVE_FULL, "StoreFullPath")]
+        public EnumerationValue StoreFullPath => this[SAVE_FULL];
 
         [EnumValue(SAVE_RELATIVE, "StoreRelativePath")]
-        public EnumerationValue StoreRelativePath
-        {
-            get
-            {
-                return this[SAVE_RELATIVE];
-            }
-        }
+        public EnumerationValue StoreRelativePath => this[SAVE_RELATIVE];
 
-        [EnumValue(SAVE_FULL, "StoreFullPath")]
-        public EnumerationValue StoreFullPath
-        {
-            get
-            {
-                return this[SAVE_FULL];
-            }
-        }
+        [EnumValue(DONT_SAVE, "DontStorePath")]
+        public EnumerationValue DontStorePath => this[DONT_SAVE];
 
         public static ZipStorePathModeEnum CreateInstance()
         {

--- a/src/ScriptEngine.HostedScript/TemplateStorage.cs
+++ b/src/ScriptEngine.HostedScript/TemplateStorage.cs
@@ -83,9 +83,9 @@ namespace ScriptEngine.HostedScript
     [EnumerationType("ТипМакета", "TemplateKind")]
     public enum TemplateKind
     {
-        [EnumItem("Файл")]
+        [EnumItem("Файл","File")]
         File,
-        [EnumItem("ДвоичныеДанные")]
+        [EnumItem("ДвоичныеДанные", "BinaryData")]
         BinaryData
     }
     

--- a/src/ScriptEngine/Machine/Contexts/EnumerationContext.cs
+++ b/src/ScriptEngine/Machine/Contexts/EnumerationContext.cs
@@ -65,6 +65,11 @@ namespace ScriptEngine.Machine.Contexts
             return _values.IndexOf(enumVal);
         }
 
+        public override int GetPropCount()
+        {
+            return _values.Count;
+        }
+
         public override int FindProperty(string name)
         {
             int id;
@@ -83,6 +88,12 @@ namespace ScriptEngine.Machine.Contexts
         {
             return _values[propNum];
         }
+
+        public override string GetPropName(int propNum)
+        {
+            return _values[propNum].AsString();
+        }
+
 
         protected IList<EnumerationValue> ValuesInternal
         {

--- a/src/ScriptEngine/Machine/Contexts/EnumerationContext.cs
+++ b/src/ScriptEngine/Machine/Contexts/EnumerationContext.cs
@@ -9,7 +9,7 @@ using System.Collections.Generic;
 
 namespace ScriptEngine.Machine.Contexts
 {
-    public class EnumerationContext : PropertyNameIndexAccessor
+    public class EnumerationContext : PropertyNameIndexAccessor, ICollectionContext
     {
         private readonly List<EnumerationValue> _values = new List<EnumerationValue>();
 
@@ -91,5 +91,26 @@ namespace ScriptEngine.Machine.Contexts
                 return _values;
             }
         }
+
+        #region ICollectionContext Members
+
+        public int Count()
+        {
+            return _values.Count;
+        }
+
+        public CollectionEnumerator GetManagedIterator()
+        {
+            return new CollectionEnumerator(GetEnumerator());
+        }
+        public IEnumerator<IValue> GetEnumerator()
+        {
+            foreach (var item in _values)
+            {
+                yield return item;
+            }
+        }
+
+        #endregion
     }
 }


### PR DESCRIPTION
Итератор сделан добавлением в перечисления функций `ICollectionContext`.
Порядок значений перечислений согласован с базовой платформой. Дополнительные значения добавлены в конец.
Русские имена установлены как первичные. Добавлены недостающие алиасы.
Рефакторинг: get-only properties переделаны на стрелочные.
Отсутствие у перечислений реализации функций `GetPropCount()` и `GetPropName()` вызывало в отладчике исключение, если имелась переменная типа `Перечисление...` (напр. `частидаты=ЧастиДаты;`)
