### PR TITLE
fix #1145 и поправки к #1146

### DIFF
--- a/src/ScriptEngine.HostedScript/Library/RandomNumberGenerator.cs
+++ b/src/ScriptEngine.HostedScript/Library/RandomNumberGenerator.cs
@@ -26,34 +26,30 @@ namespace ScriptEngine.HostedScript.Library
         [ContextMethod("СлучайноеЧисло", "RandomNumber")]
         public IValue RandomNumber(uint? low = null, uint? high = null)
         {
-            long lo64 = 0, hi64 = UInt32.MaxValue;
+            uint lo = low !=null ? (uint)low : 0;
+            uint hi = high != null ? (uint)high : uint.MaxValue;
 
-            if (low != null)
-                lo64 = (uint)low;
-
-            if (high != null)
-                hi64 = (uint)high;
-
-            if (lo64 < 0 || lo64 > 4294967295)
+            if (hi < lo)
                 throw RuntimeException.InvalidArgumentValue();
 
-            if (hi64 < 0 || hi64 > 4294967295)
-                throw RuntimeException.InvalidArgumentValue();
-
-            if (hi64 < lo64)
-                throw RuntimeException.InvalidArgumentValue();
+            uint range = hi - lo;
+            if (range == uint.MaxValue)
+                return ValueFactory.Create( Random32() );
 
             // Приводим к рабочему диапазону
-            lo64 += Int32.MinValue;
-            hi64 += Int32.MinValue;
+            long maxValue = int.MinValue + range + 1;
 
-            int lo = (int)lo64, hi = (int)hi64;
+            long v = _random.Next(int.MinValue, (int)maxValue );
+            v -= int.MinValue - lo;
 
-            int v = _random.Next(lo, hi);
-            long v64 = v;
-            v64 -= Int32.MinValue;
+            return ValueFactory.Create( v );
+        }
 
-            return ValueFactory.Create( v64 );
+        private uint Random32()
+        {
+            byte[] bytes = new byte[4];
+            _random.NextBytes(bytes);
+            return BitConverter.ToUInt32(bytes, 0);
         }
 
         /// <summary>

--- a/src/ScriptEngine.HostedScript/Library/RandomNumberGenerator.cs
+++ b/src/ScriptEngine.HostedScript/Library/RandomNumberGenerator.cs
@@ -15,12 +15,14 @@ namespace ScriptEngine.HostedScript.Library
     {
         private readonly Random _random;
 
-        public RandomNumberGenerator(int seed = 0)
+        public RandomNumberGenerator()
         {
-            if (seed == 0)
-                _random = new Random();
-            else
-                _random = new Random(seed);
+            _random = new Random();
+        }
+
+        public RandomNumberGenerator(int seed)
+        {
+            _random = new Random(seed);
         }
 
         [ContextMethod("СлучайноеЧисло", "RandomNumber")]
@@ -60,13 +62,19 @@ namespace ScriptEngine.HostedScript.Library
         [ScriptConstructor(Name = "Конструктор по умолчанию")]
         public static RandomNumberGenerator Constructor(IValue seed)
         {
-            seed = seed.GetRawValue();
-            if (seed.DataType != DataType.Number)
-                throw RuntimeException.InvalidArgumentType(1, nameof(seed));
+            decimal seedNum;
+            try
+            {
+                seedNum = seed.GetRawValue().AsNumber();
+            }
+            catch
+            {
+                throw RuntimeException.InvalidArgumentType();
+            }
 
-            var seedNum = seed.AsNumber();
+            if (seedNum == 0)
+                return new RandomNumberGenerator();
 
-            // надо как-то привести к размеру системного seed int, но не совсем рандомно, а более стабильно
             int seedInt;
             if (seedNum < int.MinValue || seedNum > int.MaxValue)
             {


### PR DESCRIPTION
К #1145: проверка входных значений убрана, т.к. она делается при передаче параметров;
для полного диапазона 0..2^32-1  - обход особенности .Net (а в 6-м появилась Random.Next64)
К #1146: допускается значение нечислового типа, если оно может быть приведено к числу (так в платформе);
отсутствию начального числа соответсвует строго нулевое значение, прочие же преобразуемые в целочисленный ноль (напр. 0.01 или 4294967296) считаются как заданное начальное число = 0, и последовательность воспроизводится;
