### PR TITLE
Исправлена ошибка количества аргументов функционального варианта Новый()

### DIFF
--- a/src/ScriptEngine/Compiler/StackMachineCodeGenerator.cs
+++ b/src/ScriptEngine/Compiler/StackMachineCodeGenerator.cs
@@ -907,44 +907,48 @@ namespace ScriptEngine.Compiler
         {
             if (node.IsDynamic)
             {
-                VisitExpression(node.TypeNameNode);
+                MakeNewObjectDynamic(node);
             }
             else
             {
-                var cDef = new ConstDefinition()
-                {
-                    Type = DataType.String,
-                    Presentation = node.TypeNameNode.GetIdentifier()
-                };
-
-                AddCommand(OperationCode.PushConst, GetConstNumber(cDef));
+                MakeNewObjectStatic(node);
             }
+        }
+        
+        private void MakeNewObjectDynamic(NewObjectNode node)
+        {
+            VisitExpression(node.TypeNameNode);
 
-            if (node.IsDynamic)
+            var argsPassed = node.ConstructorArguments.Children.Count;
+            if (argsPassed == 1)
             {
-                var argsPassed = node.ConstructorArguments.Children.Count;
-                if (argsPassed == 1)
-                {
-                    PushArgumentsList(node.ConstructorArguments);
-                }
-                else if (argsPassed > 1)
-                {
-                    AddError(CompilerErrors.TooManyArgumentsPassed(), node.ConstructorArguments.Location);
-                }
-
-                AddCommand(OperationCode.NewFunc, argsPassed);
+                PushArgumentsList(node.ConstructorArguments);
             }
-            else
+            else if (argsPassed > 1)
             {
-                var callArgs = 0;
-                if (node.ConstructorArguments != default)
-                {
-                    PushArgumentsList(node.ConstructorArguments);
-                    callArgs = node.ConstructorArguments.Children.Count;
-                }
-
-                AddCommand(OperationCode.NewInstance, callArgs);
+                AddError(CompilerErrors.TooManyArgumentsPassed(), node.ConstructorArguments.Location);
             }
+
+            AddCommand(OperationCode.NewFunc, argsPassed);
+        }
+        
+        private void MakeNewObjectStatic(NewObjectNode node)
+        {
+            var cDef = new ConstDefinition()
+            {
+                Type = DataType.String,
+                Presentation = node.TypeNameNode.GetIdentifier()
+            };
+            AddCommand(OperationCode.PushConst, GetConstNumber(cDef));
+
+            var callArgs = 0;
+            if (node.ConstructorArguments != default)
+            {
+                PushArgumentsList(node.ConstructorArguments);
+                callArgs = node.ConstructorArguments.Children.Count;
+            }
+
+            AddCommand(OperationCode.NewInstance, callArgs);
         }
 
         private void ExitTryBlocks()


### PR DESCRIPTION
При вызове  функционального варианта оператора `Новый()` с одним аргументом возникала ошибка _"Недостаточно фактических параметров"_ (отмечено в PR #1168)

Ошибка вызвана неверным слиянием коммита aeacfe2 с веткой v2:
- в компиляторе v1 `BuildArgumentList()` включал в том числе и первый аргумент, указывающий тип;
- в компиляторе v2 первый аргумент выделяется в отдельный узел `TypeNameNode` и не попадает в `ConstructorArguments`