### PR TITLE
Рефакторинг вызова методов модулей

### DIFF
--- a/src/ScriptEngine/Machine/MachineInstance.cs
+++ b/src/ScriptEngine/Machine/MachineInstance.cs
@@ -64,17 +64,7 @@ namespace ScriptEngine.Machine
         
         public void AttachContext(IAttachableContext context)
         {
-            IVariable[] vars;
-            MethodInfo[] methods;
-            context.OnAttach(this, out vars, out methods);
-            var scope = new Scope()
-            {
-                Variables = vars,
-                Methods = methods,
-                Instance = context
-            };
-
-            _scopes.Add(scope);
+            _scopes.Add(CreateModuleScope(context));
         }
 
         private Scope CreateModuleScope(IAttachableContext context)
@@ -300,7 +290,6 @@ namespace ScriptEngine.Machine
             var result = runner._operationStack.Pop();
 
             return result;
-
         }
 
         private LoadedModule CompileCached(string code, Func<string, LoadedModule> compile)
@@ -493,8 +482,6 @@ namespace ScriptEngine.Machine
                     // Сделаем это
                     while (_operationStack.Count > handler.stackSize)
                         _operationStack.Pop();
-                    
-
                 }
             }
         }
@@ -769,7 +756,6 @@ namespace ScriptEngine.Machine
             var op1 = _operationStack.Pop();
             _operationStack.Push(ValueFactory.Add(op1, op2));
             NextInstruction();
-
         }
 
         private void Sub(int arg)
@@ -878,7 +864,6 @@ namespace ScriptEngine.Machine
                 _operationStack.Pop();
                 NextInstruction();
             }
-            
         }
 
         private void Or(int arg)
@@ -984,16 +969,14 @@ namespace ScriptEngine.Machine
             {
                 realArgs = new IValue[methInfo.ArgCount];
                 var skippedArg = ValueFactory.CreateInvalidValueMarker();
-                for (int i = 0; i < realArgs.Length; i++)
+                int i = 0;
+                for (; i < argValues.Length; i++)
                 {
-                    if (i < argValues.Length)
-                    {
-                        realArgs[i] = argValues[i];
-                    }
-                    else
-                    {
-                        realArgs[i] = skippedArg;
-                    }
+                    realArgs[i] = argValues[i];
+                }
+                for (; i < realArgs.Length; i++)
+                {
+                    realArgs[i] = skippedArg;
                 }
             }
             else
@@ -1003,8 +986,7 @@ namespace ScriptEngine.Machine
 
             if (asFunc)
             {
-                IValue retVal;
-                instance.CallAsFunction(index, realArgs, out retVal);
+                instance.CallAsFunction(index, realArgs, out IValue retVal);
                 _operationStack.Push(retVal);
             }
             else
@@ -1041,7 +1023,6 @@ namespace ScriptEngine.Machine
             var propReference = Variable.CreateContextPropertyReference(context, propNum, "stackvar");
             _operationStack.Push(propReference);
             NextInstruction();
-
         }
 
         private void ResolveMethodProc(int arg)
@@ -1053,7 +1034,6 @@ namespace ScriptEngine.Machine
 
             context.CallAsProcedure(methodId, argValues);
             NextInstruction();
-
         }
 
         private void ResolveMethodFunc(int arg)
@@ -1068,8 +1048,7 @@ namespace ScriptEngine.Machine
                 throw RuntimeException.UseProcAsAFunction();
             }
 
-            IValue retVal;
-            context.CallAsFunction(methodId, argValues, out retVal);
+            context.CallAsFunction(methodId, argValues, out IValue retVal);
             _operationStack.Push(retVal);
             NextInstruction();
         }
@@ -1124,7 +1103,6 @@ namespace ScriptEngine.Machine
                     else if(!methodParams[i].HasDefaultValue)
                         throw RuntimeException.MissedArgument();
                 }
-
                 for (; i < methodParams.Length; i++)
                 {
                     if (!methodParams[i].HasDefaultValue)
@@ -1132,7 +1110,6 @@ namespace ScriptEngine.Machine
                 }
             }
         }
-
 
         private void Jmp(int arg)
         {
@@ -1164,7 +1141,6 @@ namespace ScriptEngine.Machine
 
             _operationStack.Push(Variable.CreateIndexedPropertyReference(context, index, "$stackvar"));
             NextInstruction();
-
         }
 
         private void Return(int arg)
@@ -1241,7 +1217,6 @@ namespace ScriptEngine.Machine
             var instance = constructor(typeName, argValues);
             _operationStack.Push(instance);
             NextInstruction();
-
         }
 
         private void PushIterator(int arg)
@@ -1258,7 +1233,6 @@ namespace ScriptEngine.Machine
                 var iterator = context.GetManagedIterator();
                 _currentFrame.LocalFrameStack.Push(iterator);
                 NextInstruction();
-
             }
             else
             {
@@ -1434,7 +1408,6 @@ namespace ScriptEngine.Machine
             }
 
             NextInstruction();
-
         }
 
 
@@ -1613,7 +1586,6 @@ namespace ScriptEngine.Machine
 
             _operationStack.Push(ValueFactory.Create(""));
             NextInstruction();
-
         }
 
         private void TrimR(int arg)
@@ -1634,7 +1606,6 @@ namespace ScriptEngine.Machine
 
             _operationStack.Push(ValueFactory.Create(""));
             NextInstruction();
-
         }
 
         private void TrimLR(int arg)
@@ -1893,7 +1864,6 @@ namespace ScriptEngine.Machine
             }
 
             _operationStack.Push(ValueFactory.Create(entryCount));
-
             NextInstruction();
         }
 

--- a/src/ScriptEngine/Machine/MachineInstance.cs
+++ b/src/ScriptEngine/Machine/MachineInstance.cs
@@ -104,11 +104,7 @@ namespace ScriptEngine.Machine
             {
                 var entryRef = module.MethodRefs[module.EntryMethodIndex];
                 PrepareReentrantMethodExecution(sdo, entryRef.CodeIndex);
-                var methDescr = module.Methods[entryRef.CodeIndex];
-                for (int i = 0; i < _currentFrame.Locals.Length; i++)
-                {
-                    _currentFrame.Locals[i] = Variable.Create(ValueFactory.Create(), methDescr.Variables[i]);
-                }
+                CreateCurrentFrameLocals(module.Methods[entryRef.CodeIndex].Variables);
 
                 ExecuteCode();
                 if (_callStack.Count > 1)
@@ -182,6 +178,15 @@ namespace ScriptEngine.Machine
                 locals[i] = Variable.Create(value, variables[i]);
             }
             for (; i < locals.Length; i++)
+            {
+                locals[i] = Variable.Create(ValueFactory.Create(), variables[i]);
+            }
+        }
+
+        private void CreateCurrentFrameLocals(VariablesFrame variables)
+        {
+            var locals = _currentFrame.Locals;
+            for (int i = 0; i < locals.Length; i++)
             {
                 locals[i] = Variable.Create(ValueFactory.Create(), variables[i]);
             }
@@ -1413,14 +1418,11 @@ namespace ScriptEngine.Machine
                 Locals = new IVariable[method.Variables.Count],
                 InstructionPointer = 0,
             };
-            for (int i = 0; i < frame.Locals.Length; i++)
-            {
-                frame.Locals[i] = Variable.Create(ValueFactory.Create(), method.Variables[i]);
-            }
+            PushFrame(frame);
+            CreateCurrentFrameLocals(method.Variables);
 
             try
             {
-                PushFrame(frame);
                 MainCommandLoop();
             }
             finally

--- a/src/ScriptEngine/Machine/MachineInstance.cs
+++ b/src/ScriptEngine/Machine/MachineInstance.cs
@@ -723,19 +723,19 @@ namespace ScriptEngine.Machine
         {
             var vm = _module.VariableRefs[arg];
             var scope = _scopes[vm.ContextIndex];
-            scope.Variables[vm.CodeIndex].Value = BreakVariableLink(_operationStack.Pop());
+            scope.Variables[vm.CodeIndex].Value = PopRawValue();
             NextInstruction();
         }
-
+        
         private void LoadLoc(int arg)
         {
-            _currentFrame.Locals[arg].Value = BreakVariableLink(_operationStack.Pop());
+            _currentFrame.Locals[arg].Value = PopRawValue();
             NextInstruction();
         }
 
         private void AssignRef(int arg)
         {
-            var value = BreakVariableLink(_operationStack.Pop());
+            var value = PopRawValue();
 
             IVariable reference;
             try
@@ -1076,7 +1076,7 @@ namespace ScriptEngine.Machine
                     var argValue = factArgs[i];
                     if (argValue.DataType != DataType.NotAValidValue)
                     {
-                        argValues[i] = BreakVariableLink(argValue);
+                        argValues[i] = argValue.GetRawValue();
                     }
                 }
             }
@@ -1096,11 +1096,11 @@ namespace ScriptEngine.Machine
                     if (argValue.DataType != DataType.NotAValidValue)
                     {
                         if (methodParams[i].IsByValue)
-                            argValues[i] = BreakVariableLink(argValue);
+                            argValues[i] = argValue.GetRawValue();
                         else
                             argValues[i] = argValue;
                     }
-                    else if(!methodParams[i].HasDefaultValue)
+                    else if (!methodParams[i].HasDefaultValue)
                         throw RuntimeException.MissedArgument();
                 }
                 for (; i < methodParams.Length; i++)
@@ -1132,7 +1132,7 @@ namespace ScriptEngine.Machine
 
         private void PushIndexed(int arg)
         {
-            var index = BreakVariableLink(_operationStack.Pop());
+            var index = PopRawValue();
             var context = _operationStack.Pop().AsObject();
             if (context == null || !context.IsIndexed)
             {
@@ -1202,7 +1202,7 @@ namespace ScriptEngine.Machine
             {
                 var argValue = _operationStack.Pop();
                 if(argValue.DataType != DataType.NotAValidValue)
-                    argValues[i] = BreakVariableLink(argValue);
+                    argValues[i] = argValue.GetRawValue();
             }
 
             var typeName = _operationStack.Pop().AsString();
@@ -1343,7 +1343,7 @@ namespace ScriptEngine.Machine
 
         private void MakeRawValue(int arg)
         {
-            var value = BreakVariableLink(_operationStack.Pop());
+            var value = PopRawValue();
             _operationStack.Push(value);
             NextInstruction();
         }
@@ -2294,7 +2294,7 @@ namespace ScriptEngine.Machine
                     min = current;
             }
 
-            _operationStack.Push(BreakVariableLink(min));
+            _operationStack.Push(min.GetRawValue());
 
             NextInstruction();
         }
@@ -2311,7 +2311,7 @@ namespace ScriptEngine.Machine
                     max = current;
             }
 
-            _operationStack.Push(BreakVariableLink(max));
+            _operationStack.Push(max.GetRawValue());
             NextInstruction();
         }
 
@@ -2477,9 +2477,9 @@ namespace ScriptEngine.Machine
             _currentFrame.InstructionPointer++;
         }
 
-        private IValue BreakVariableLink(IValue value)
+        private IValue PopRawValue()
         {
-            return value.GetRawValue();
+            return _operationStack.Pop().GetRawValue();
         }
 
         public IList<ExecutionFrameInfo> GetExecutionFrames()


### PR DESCRIPTION
Переделано создание фреймов при обработке CallProc/CallFunc/Evaluate/Execute.
Вынесена процедура установки значений параметров и локальных переменных.
Т.к. теперь в описании параметра есть значение по умолчанию, упрощено получение этих значений для пропущенных параметров.
Работает немного быстрее.
_Spaghetti unwinding in progress_