### PR TITLE
fix #1266: в отладчике вычислять watch с учетом кадра стека

### DIFF
--- a/src/OneScript.DebugServices/DefaultDebugService.cs
+++ b/src/OneScript.DebugServices/DefaultDebugService.cs
@@ -71,7 +71,6 @@ namespace OneScript.DebugServices
                         Source = item.Key
                     });
                 }
-
             }
 
             // Уведомить все потоки о новых точках остановки
@@ -91,13 +90,14 @@ namespace OneScript.DebugServices
             int index = 0;
             foreach (var frameInfo in frames)
             {
-                var frame = new StackFrame();
-                frame.LineNumber = frameInfo.LineNumber;
-                frame.Index = index++;
-                frame.MethodName = frameInfo.MethodName;
-                frame.Source = frameInfo.Source;
+                var frame = new StackFrame
+                {
+                    LineNumber = frameInfo.LineNumber,
+                    Index = index++,
+                    MethodName = frameInfo.MethodName,
+                    Source = frameInfo.Source
+                };
                 result[frame.Index] = frame;
-
             }
             return result;
         }
@@ -127,7 +127,7 @@ namespace OneScript.DebugServices
 
             try
             {
-                value = GetMachine(threadId).Evaluate(expression, true);
+                value = GetMachine(threadId).EvaluateInFrame(expression, frameIndex);
             }
             catch (Exception e)
             {
@@ -150,7 +150,7 @@ namespace OneScript.DebugServices
             try
             {
                 var value = GetMachine(threadId)
-                    .Evaluate(expression, true)
+                    .EvaluateInFrame(expression, contextFrame)
                     .GetRawValue();
                 
                 var variable = _visualizer.GetVariable(MachineVariable.Create(value, "$evalResult"));

--- a/src/ScriptEngine/Machine/MachineInstance.cs
+++ b/src/ScriptEngine/Machine/MachineInstance.cs
@@ -271,14 +271,14 @@ namespace ScriptEngine.Machine
         {
             System.Diagnostics.Debug.Assert(_fullCallstackCache != null);
             if (frameId < 0 || frameId >= _fullCallstackCache.Count)
-                return ValueFactory.Create();
+                throw new ScriptException("Wrong stackframe");
 
             ExecutionFrame selectedFrame = _fullCallstackCache[frameId].FrameObject;
 
             MachineInstance currentMachine;
             MachineInstance runner = new MachineInstance
             {
-                _scopes = new List<Scope>(_scopes.GetRange(0, selectedFrame.ModuleLoadIndex + 1)),
+                _scopes = new List<Scope>(this._scopes.GetRange(0, selectedFrame.ModuleLoadIndex + 1)),
                 _debugInfo = _module.ModuleInfo
             };
 
@@ -293,21 +293,21 @@ namespace ScriptEngine.Machine
                 var code = runner.CompileExpressionModule(expression);
 
                 code.ModuleInfo.Origin = selectedFrame.Module.ModuleInfo.Origin;
-                code.ModuleInfo.ModuleName = "<dbg expression>";
+                code.ModuleInfo.ModuleName = "<debug expression>";
 
-                var mlocals = new Scope
+                var localScope = new Scope
                 {
                     Instance = new UserScriptContextInstance(code),
                     Methods = selectedFrame.ModuleScope.Methods,
                     Variables = selectedFrame.Locals
                 };
-                runner._scopes.Add(mlocals);
+                runner._scopes.Add(localScope);
 
                 frame = new ExecutionFrame
                 {
                     MethodName = code.ModuleInfo.ModuleName,
                     Module = code,
-                    ModuleScope = mlocals,
+                    ModuleScope = localScope,
                     ModuleLoadIndex = runner._scopes.Count - 1,
                     Locals = new IVariable[0],
                     InstructionPointer = 0,

--- a/src/VSCode.DebugAdapter/OscriptDebugSession.cs
+++ b/src/VSCode.DebugAdapter/OscriptDebugSession.cs
@@ -397,7 +397,7 @@ namespace VSCode.DebugAdapter
 
                 if (evalResult.IsStructured)
                 {
-                    var loc = new EvaluatedVariableLocator(expression, frame.ThreadId, frameId);
+                    var loc = new EvaluatedVariableLocator(expression, frame.ThreadId, frame.Index);
                     id = _variableHandles.Create(loc);
                 }
             }

--- a/src/oscript/DebugServer/DebugServiceImpl.cs
+++ b/src/oscript/DebugServer/DebugServiceImpl.cs
@@ -74,7 +74,6 @@ namespace oscript.DebugServer
                         Source = item.Key
                     });
                 }
-
             }
 
             return confirmedBreakpoints.ToArray();
@@ -88,13 +87,14 @@ namespace oscript.DebugServer
             int index = 0;
             foreach (var frameInfo in frames)
             {
-                var frame = new StackFrame();
-                frame.LineNumber = frameInfo.LineNumber;
-                frame.Index = index++;
-                frame.MethodName = frameInfo.MethodName;
-                frame.Source = frameInfo.Source;
+                var frame = new StackFrame
+                {
+                    LineNumber = frameInfo.LineNumber,
+                    Index = index++,
+                    MethodName = frameInfo.MethodName,
+                    Source = frameInfo.Source
+                };
                 result[frame.Index] = frame;
-
             }
             return result;
         }
@@ -125,7 +125,7 @@ namespace oscript.DebugServer
 
             try
             {
-                value = GetMachine(threadId).Evaluate(expression, true);
+                value = GetMachine(threadId).EvaluateInFrame(expression, frameIndex);
             }
             catch (Exception e)
             {
@@ -147,7 +147,7 @@ namespace oscript.DebugServer
         {
             try
             {
-                var value = GetMachine(threadId).Evaluate(expression, true);
+                var value = GetMachine(threadId).EvaluateInFrame(expression, contextFrame);
                 
                 var variable = CreateDebuggerVariable("$evalResult",
                     value.AsString(), value.SystemType.Name);


### PR DESCRIPTION
Исправлена ошибка, не позволявшая раскрывать структурные переменные.
Функция вычисления выражений для выбранного кадра стека отделена от основной `Вычислить()`
