### PR TITLE
#1272 fix: v2 - Использовать ShellExecute при запуске процесса

### DIFF
--- a/src/OneScript.StandardLibrary/Processes/ProcessContext.cs
+++ b/src/OneScript.StandardLibrary/Processes/ProcessContext.cs
@@ -270,6 +270,7 @@ namespace OneScript.StandardLibrary.Processes
             var sInfo = new ProcessStartInfo();
 
             int argsPosition;
+            sInfo.UseShellExecute = true;
             sInfo.FileName = ExtractExecutableName(cmdLine, out argsPosition);
             sInfo.Arguments = argsPosition >= cmdLine.Length ? "" : cmdLine.Substring(argsPosition);
             if (currentDir != null)


### PR DESCRIPTION
Как верно подметил @EvilBeaver ссылками в комментах к #1272 , net core в отличии от классического фреймворка при создании ProcessStartInfo UseShellExecute имеет значение false

Явное указание UseShellExecute = true решает проблему, проверено на последней МакОСи

