### PR TITLE
#1278 fix: v2 - Поддержка возрата из процедуры, проверка вызова процедуры как функции

### DIFF
--- a/src/OneScript.Language/SyntaxAnalysis/LocalizedErrors.cs
+++ b/src/OneScript.Language/SyntaxAnalysis/LocalizedErrors.cs
@@ -123,6 +123,9 @@ namespace OneScript.Language.SyntaxAnalysis
         public static CodeError UseBuiltInFunctionAsProcedure() =>
             Create("Использование встроенной функции, как процедуры", "Using build-in function as procedure");
         
+        public static CodeError UseProcAsFunction() =>
+            Create("Использование процедуры, как функции", "Procedure called as function");
+        
         public static CodeError DuplicateVarDefinition(string varName) =>
             Create($"Переменная {varName} уже определена", $"Variable {varName} already defined");
         

--- a/src/OneScript.Native/Compiler/MethodCompiler.cs
+++ b/src/OneScript.Native/Compiler/MethodCompiler.cs
@@ -1067,18 +1067,17 @@ namespace OneScript.Native.Compiler
 
         protected override void VisitGlobalFunctionCall(CallNode node)
         {
-            if (!_method.IsFunction())
-            {
-                AddError(LocalizedErrors.UseProcAsFunction(), node.Location);
-                return;
-            }
-            
             if (LanguageDef.IsBuiltInFunction(node.Identifier.Lexem.Token))
             {
                 _statementBuildParts.Push(CreateBuiltInFunctionCall(node));
                 return;
             }
-            
+
+            if (!_method.IsFunction())
+            {
+                AddError(LocalizedErrors.UseProcAsFunction(), node.Location);
+            }
+
             var expression = CreateMethodCall(node);
             _statementBuildParts.Push(expression);
         }

--- a/src/Tests/OneScript.Dynamic.Tests/Compiler_Api_Tests.cs
+++ b/src/Tests/OneScript.Dynamic.Tests/Compiler_Api_Tests.cs
@@ -136,6 +136,37 @@ namespace OneScript.Dynamic.Tests
             errors.Should().BeEmpty();
         }
 
+        [Fact]
+        public void CanCompile_Proc_With_Return()
+        {
+            var code = @"
+            Процедура Тест()
+                Возврат;
+            КонецПроцедуры";
+            
+            var errors = new List<CodeError>();
+            CreateModule(code, errors);
+            
+            errors.Should().BeEmpty();
+        }
+        
+        [Fact]
+        public void Detects_Proc_As_Func_Invoke()
+        {
+            var code = @"
+            Процедура Тест()
+                
+            КонецПроцедуры
+
+            a = Тест();";
+            
+            var errors = new List<CodeError>();
+            CreateModule(code, errors);
+            
+            errors.Should().HaveCount(1);
+            errors[0].ErrorId.Should().Be(nameof(LocalizedErrors.UseProcAsFunction));
+        }
+
         private DynamicModule CreateModule(string code)
         {
             var helper = new CompileHelper();


### PR DESCRIPTION
#1278 Фикс кейса "ПроцедураCВозвратом" от @sfaqer

т.к вернуть void в текущей реализации довольно сложная затея, то решил возращать BslUndefinedValue

При этом добавил проверки на вызов процедуры как функции, иначе можно было спокойно вызывать процедуры как функции и получить неопределено :)