### PR TITLE
native: дополнения типов к преобразованиям Bsl в Clr. Fix #1294

### DIFF
--- a/src/OneScript.Native/Compiler/CompilerHelpers.cs
+++ b/src/OneScript.Native/Compiler/CompilerHelpers.cs
@@ -28,6 +28,7 @@ namespace OneScript.Native.Compiler
                 LexemType.StringLiteral => BslStringValue.Create(lex.Content),
                 LexemType.DateLiteral => BslDateValue.Parse(lex.Content),
                 LexemType.UndefinedLiteral => BslUndefinedValue.Instance,
+                LexemType.NullLiteral => BslNullValue.Instance,
                 _ => throw new NotImplementedException()
             };
         }
@@ -41,6 +42,7 @@ namespace OneScript.Native.Compiler
                 LexemType.StringLiteral => (string)BslStringValue.Create(lex.Content),
                 LexemType.DateLiteral => (DateTime)BslDateValue.Parse(lex.Content),
                 LexemType.UndefinedLiteral => BslUndefinedValue.Instance,
+                LexemType.NullLiteral => BslNullValue.Instance,
                 _ => throw new NotImplementedException()
             };
         }

--- a/src/OneScript.Native/Compiler/ExpressionHelpers.cs
+++ b/src/OneScript.Native/Compiler/ExpressionHelpers.cs
@@ -382,7 +382,7 @@ namespace OneScript.Native.Compiler
             var factoryClass = GetValueFactoryType(value.Type);
             if (factoryClass == null)
             {
-                if (value.Type == typeof(object))
+                if (value.Type==typeof(IValue) || value.Type.IsSubclassOf(typeof(IValue)))
                 {
                     // это результат динамической операции
                     // просто верим, что он BslValue
@@ -432,15 +432,9 @@ namespace OneScript.Native.Compiler
             {
                 factoryClass = typeof(BslBooleanValue);
             }
-            else if (clrType == typeof(decimal))
+            else if (clrType.IsNumeric())
             {
-                factoryClass = typeof(BslNumericValue);
-            }
-            else if (clrType == typeof(int) ||
-                     clrType == typeof(long) ||
-                     clrType == typeof(double))
-            {
-                factoryClass = typeof(BslNumericValue);
+                 factoryClass = typeof(BslNumericValue);
             }
             else if (clrType == typeof(DateTime))
             {

--- a/src/OneScript.Native/Runtime/DynamicOperations.cs
+++ b/src/OneScript.Native/Runtime/DynamicOperations.cs
@@ -95,8 +95,16 @@ namespace OneScript.Native.Runtime
                 null => BslUndefinedValue.Instance,
                 string s => BslStringValue.Create(s),
                 decimal d => BslNumericValue.Create(d),
+
                 int n => BslNumericValue.Create(n),
+                uint n => BslNumericValue.Create(n),
+                short n => BslNumericValue.Create(n),
+                ushort n => BslNumericValue.Create(n),
+                byte n => BslNumericValue.Create(n),
+                sbyte n => BslNumericValue.Create(n),
                 long l => BslNumericValue.Create(l),
+                ulong l => BslNumericValue.Create(l),
+                
                 double dbl => BslNumericValue.Create((decimal) dbl),
                 bool boolean => BslBooleanValue.Create(boolean),
                 DateTime date => BslDateValue.Create(date),


### PR DESCRIPTION
Для v2 native:
- добавлена обработка значения `NULL`
- добавлены все целочисленные типы
- обработка динамических операций типов `IValue`
Устраняет множество ошибок работы со стандартной библиотекой.
Остаётся  нерешённой проблема с перечислениями