### PR TITLE
к #1294: вернул общий случай результата динамической операции

### DIFF
--- a/src/OneScript.Native/Compiler/ExpressionHelpers.cs
+++ b/src/OneScript.Native/Compiler/ExpressionHelpers.cs
@@ -382,7 +382,8 @@ namespace OneScript.Native.Compiler
             var factoryClass = GetValueFactoryType(value.Type);
             if (factoryClass == null)
             {
-                if (value.Type==typeof(IValue) || value.Type.IsSubclassOf(typeof(IValue)))
+                if (value.Type==typeof(IValue) || value.Type.IsSubclassOf(typeof(IValue)) 
+                    || value.Type == typeof(object))
                 {
                     // это результат динамической операции
                     // просто верим, что он BslValue
@@ -404,6 +405,7 @@ namespace OneScript.Native.Compiler
             var factory = OperationsCache.GetOrAdd(factoryClass, "Create");
             return Expression.Call(factory, value);
         }
+
         public static (Expression, Expression) ConvertToCompatibleBslValues(Expression value1, Expression value2)
         {
             value1 = ConvertToBslValue(value1);


### PR DESCRIPTION
Частичный откат. Причины:
- для системных коллекций (напр. `Массив`) функция `IsObjectValue()`  возвращает false, хотя они являются наследниками  `BslObjectValue`
- при компиляции вызова методов-процедур вместо возврата `void` ожидается `object`

