### PR TITLE
fix #1302: контроль обязательных параметров встроенных функций (v2)

### DIFF
--- a/src/ScriptEngine/Compiler/CompilerErrors.cs
+++ b/src/ScriptEngine/Compiler/CompilerErrors.cs
@@ -21,7 +21,10 @@ namespace ScriptEngine.Compiler
 
         public static CodeError TooManyArgumentsPassed() =>
             Create("Слишком много фактических параметров", "Too many actual parameters");
-        
+
+        public static CodeError MissedArgument() =>
+            Create("Пропущен обязательный параметр", "Missed mandatory parameter");
+
         private static CodeError Create(string ru, string en, [CallerMemberName] string errorId = default)
         {
             return new CodeError

--- a/src/ScriptEngine/Compiler/StackMachineCodeGenerator.cs
+++ b/src/ScriptEngine/Compiler/StackMachineCodeGenerator.cs
@@ -604,7 +604,7 @@ namespace ScriptEngine.Compiler
             else
             {
                 var parameters = BuiltinFunctions.ParametersInfo(funcId);
-                CheckFactArguments(parameters, node.ArgumentList);
+                FullCheckFactArguments(parameters, node.ArgumentList);
             }
 
             AddCommand(funcId, argsPassed);
@@ -629,7 +629,34 @@ namespace ScriptEngine.Compiler
         {
             CheckFactArguments(method.GetParameters(), argList);
         }
-        
+
+        private void FullCheckFactArguments(ParameterInfo[] parameters, BslSyntaxNode argList)
+        {
+            var argsPassed = argList.Children.Count;
+            if (argsPassed > parameters.Length)
+            {
+                AddError(CompilerErrors.TooManyArgumentsPassed(), argList.Location);
+                return;
+            }
+
+            int i = 0;
+            for (; i < argsPassed; i++)
+            {
+                if (!parameters[i].HasDefaultValue && argList.Children[i].Children.Count == 0)
+                {
+                    AddError(CompilerErrors.MissedArgument(), argList.Location);
+                }
+            }
+            for (; i < parameters.Length; i++)
+            {
+                if (!parameters[i].HasDefaultValue)
+                {
+                    AddError(CompilerErrors.TooFewArgumentsPassed(), argList.Location);
+                    return;
+                }
+            }
+        }
+
         protected override void VisitGlobalProcedureCall(CallNode node)
         {
             if (LanguageDef.IsBuiltInFunction(node.Identifier.Lexem.Token))


### PR DESCRIPTION
В платформе проверка обязательных параметров при компиляции относится только ко встроенным (реализованным как опкод ВМ) функциям.
Для прочих же функций глобального контекста такой проверки нет, неявно передаётся значение `Неопределено` и при вызове приводится к типу аргумента, вызывая в рантайме либо падение, либо - для строковых параметров - преобразование в пустую строку. Это почти всегда противоречит документации, где параметры обозначены как обязательные.
Обычный в подобных случаях вопрос: стоит ли в точности повторять явно ошибочное поведение?