### PR TITLE
#1299 fix: Убрать экранирующие аргумент кавычки

### DIFF
--- a/src/OneScript.StandardLibrary/Processes/ArgumentsParser.cs
+++ b/src/OneScript.StandardLibrary/Processes/ArgumentsParser.cs
@@ -1,3 +1,10 @@
+/*----------------------------------------------------------
+This Source Code Form is subject to the terms of the 
+Mozilla Public License, v.2.0. If a copy of the MPL 
+was not distributed with this file, You can obtain one 
+at http://mozilla.org/MPL/2.0/.
+----------------------------------------------------------*/
+
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/src/OneScript.StandardLibrary/Processes/ArgumentsParser.cs
+++ b/src/OneScript.StandardLibrary/Processes/ArgumentsParser.cs
@@ -69,8 +69,10 @@ namespace OneScript.StandardLibrary.Processes
                 _isInQuotes = false;
                 _currentQuote = default;
             }
-            
-            PushChar(quoteChar);
+            else
+            {
+                PushChar(quoteChar);
+            }
         }
 
         private void PushChar(char ch)

--- a/src/Tests/OneScript.Core.Tests/ArgumentParserTests.cs
+++ b/src/Tests/OneScript.Core.Tests/ArgumentParserTests.cs
@@ -1,3 +1,10 @@
+/*----------------------------------------------------------
+This Source Code Form is subject to the terms of the 
+Mozilla Public License, v.2.0. If a copy of the MPL 
+was not distributed with this file, You can obtain one 
+at http://mozilla.org/MPL/2.0/.
+----------------------------------------------------------*/
+
 using FluentAssertions;
 using OneScript.StandardLibrary.Processes;
 using Xunit;

--- a/src/Tests/OneScript.Core.Tests/ArgumentParserTests.cs
+++ b/src/Tests/OneScript.Core.Tests/ArgumentParserTests.cs
@@ -7,12 +7,12 @@ namespace OneScript.Core.Tests;
 public class ArgumentParserTests
 {
     [Theory]
-    [InlineData("-c 'oscript -version'", "-c", "'oscript -version'")]
+    [InlineData("-c 'oscript -version'", "-c", "oscript -version")]
     [InlineData("-c oscript -version", "-c", "oscript", "-version")]
-    [InlineData("-c '\"oscript\" -version'", "-c", "'\"oscript\" -version'")]
-    [InlineData("-c \"'oscript' -version\"", "-c", "\"'oscript' -version\"")]
+    [InlineData("-c '\"oscript\" -version'", "-c", "\"oscript\" -version")]
+    [InlineData("-c \"'oscript' -version\"", "-c", "'oscript' -version")]
+    [InlineData("'aaa\"", "aaa\"")]
     [InlineData(" ")]
-    [InlineData("'aaa\"", "'aaa\"")]
     public void Should_Parse_Arguments(string input, params string[] expected)
     {
         var parser = new ArgumentsParser(input);


### PR DESCRIPTION
[Внимательно надо было мне доку читать :)](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.processstartinfo.argumentlist?view=net-7.0#remarks)

Каждый элемент ArgumentList экранируется автоматом, поэтому там сейчас и поломалось все