### PR TITLE
fix #1325: контроль пропущенных параметров

### DIFF
--- a/src/ScriptEngine/Machine/Contexts/ContextValuesMarshaller.cs
+++ b/src/ScriptEngine/Machine/Contexts/ContextValuesMarshaller.cs
@@ -6,6 +6,7 @@ at http://mozilla.org/MPL/2.0/.
 ----------------------------------------------------------*/
 using System;
 using System.Linq;
+using System.Reflection;
 using ScriptEngine.Machine.Values;
 
 namespace ScriptEngine.Machine.Contexts
@@ -85,6 +86,7 @@ namespace ScriptEngine.Machine.Contexts
             else if (type == typeof(ushort))
             {
                 valueObj = (ushort)value.AsNumber();
+                //valueObj = Convert.ChangeType(value.AsNumber(), type);
             }
             else if (type == typeof(uint))
             {
@@ -207,6 +209,15 @@ namespace ScriptEngine.Machine.Contexts
 
             throw RuntimeException.InvalidArgumentValue();
         }
+
+        public static IValue ConvertParameterDefaultValue(ParameterInfo paramInfo)
+        {
+            if (paramInfo.DefaultValue == null)
+                return null;
+
+            return ConvertReturnValue(paramInfo.DefaultValue, paramInfo.ParameterType);
+        }
+
 
         public static IValue ConvertDynamicValue(object param)
         {

--- a/src/ScriptEngine/Machine/Contexts/ContextValuesMarshaller.cs
+++ b/src/ScriptEngine/Machine/Contexts/ContextValuesMarshaller.cs
@@ -86,7 +86,6 @@ namespace ScriptEngine.Machine.Contexts
             else if (type == typeof(ushort))
             {
                 valueObj = (ushort)value.AsNumber();
-                //valueObj = Convert.ChangeType(value.AsNumber(), type);
             }
             else if (type == typeof(uint))
             {

--- a/src/ScriptEngine/Machine/Core.cs
+++ b/src/ScriptEngine/Machine/Core.cs
@@ -217,7 +217,8 @@ namespace ScriptEngine.Machine
         
         [NonSerialized]
         public IValue DefaultValue;
-        
+        public Type RealType;
+
         public int DefaultValueIndex;
         public AnnotationDefinition[] Annotations;
 

--- a/src/ScriptEngine/Machine/RuntimeExceptions.cs
+++ b/src/ScriptEngine/Machine/RuntimeExceptions.cs
@@ -46,19 +46,19 @@ namespace ScriptEngine.Machine
 
         public static RuntimeException ConvertToNumberException()
         {
-            return new RuntimeException("Преобразование к типу 'Число' не поддерживается");
+            return new TypeConvertionException("Число");
         }
 
         public static RuntimeException ConvertToBooleanException()
         {
-            return new RuntimeException("Преобразование к типу 'Булево' не поддерживается");
+            return new TypeConvertionException("Булево");
         }
 
         public static RuntimeException ConvertToDateException()
         {
-            return new RuntimeException("Преобразование к типу 'Дата' не поддерживается");
+            return new TypeConvertionException("Дата");
         }
-
+  
         public static RuntimeException PropIsNotReadableException(string prop)
         {
             return PropertyAccessException.GetPropIsNotReadableException(prop);
@@ -102,6 +102,11 @@ namespace ScriptEngine.Machine
         public static RuntimeException MissedArgument()
         {
             return new RuntimeException("Пропущен обязательный параметр");
+        }
+
+        public static RuntimeException MissedNthArgument(int argNum)
+        {
+            return new RuntimeException($"Пропущен обязательный параметр номер {argNum}" );
         }
 
         public static RuntimeException InvalidArgumentType()
@@ -212,6 +217,14 @@ namespace ScriptEngine.Machine
         }
 
         public int ExitCode { get; private set; }
+    }
+
+    public class TypeConvertionException : RuntimeException
+    {
+        public TypeConvertionException(string typename) 
+            : base($"Преобразование к типу '{typename}' не поддерживается")
+        {
+        }
     }
 
     public class ValueMarshallingException : RuntimeException


### PR DESCRIPTION
Показывается номер ошибочно пропущенного обязательного параметра.
Унифицирована передача параметров для методов глобального контекста и объектов. Для глобального: исправлено #1303, преобразование `NotAValidValue` в `null` для динамических вызовов.
Подстановка значений по умолчанию при разборе аргументов, в т.ч. не указанных, но допустимых для строк и объектов.
Оставшиеся цели:
- добавить строгую проверку типов, где это требуется для совместимости;
- избавиться при маршалинге от `NotAValidValue` и подстановки default для value типов;
- максимально объединить вызов методов и конструкторов;
но это всё надо отдельным issue.

Тесты проходят. Winow работает. 
