### PR TITLE
Оптимизация вызова методов

### DIFF
--- a/src/OneScript.Core.Tests/ValuesTest.cs
+++ b/src/OneScript.Core.Tests/ValuesTest.cs
@@ -28,8 +28,8 @@ namespace OneScript.Core.Tests
 
             Assert.True(BooleanValue.True.CompareTo(BooleanValue.False) > 0);
 
-            Assert.Throws<RuntimeException>(() => BooleanValue.True.AsDate());
-            Assert.Throws<RuntimeException>(() => BooleanValue.True.AsObject());
+            Assert.Throws<TypeConvertionException>(() => BooleanValue.True.AsDate());
+            Assert.Throws<TypeConvertionException>(() => BooleanValue.True.AsObject());
         }
 
         [Theory]
@@ -68,8 +68,8 @@ namespace OneScript.Core.Tests
             Assert.True(num4.CompareTo(num3) < 0);
 
             Assert.Equal("12.5", num1.AsString());
-            Assert.Throws<RuntimeException>(() => num1.AsDate());
-            Assert.Throws<RuntimeException>(() => num1.AsObject());
+            Assert.Throws<TypeConvertionException>(() => num1.AsDate());
+            Assert.Throws<TypeConvertionException>(() => num1.AsObject());
         }
 
         [Fact]
@@ -103,8 +103,8 @@ namespace OneScript.Core.Tests
             var numString = ValueFactory.Create("012.12");
             Assert.True(numString.AsNumber() == 12.12m);
 
-            Assert.Throws<RuntimeException>(() => dateString.AsObject());
-            Assert.Throws<RuntimeException>(() => trueString.AsNumber());
+            Assert.Throws<TypeConvertionException>(() => dateString.AsObject());
+            Assert.Throws<TypeConvertionException>(() => trueString.AsNumber());
         }
         
         [Fact]
@@ -114,10 +114,10 @@ namespace OneScript.Core.Tests
             Assert.True(value.DataType == DataType.Undefined);
             Assert.True(value.AsString() == "");
 
-            Assert.Throws<RuntimeException>(() => value.AsNumber());
-            Assert.Throws<RuntimeException>(() => value.AsBoolean());
-            Assert.Throws<RuntimeException>(() => value.AsObject());
-            Assert.Throws<RuntimeException>(() => value.AsDate());
+            Assert.Throws<TypeConvertionException>(() => value.AsNumber());
+            Assert.Throws<TypeConvertionException>(() => value.AsBoolean());
+            Assert.Throws<TypeConvertionException>(() => value.AsObject());
+            Assert.Throws<TypeConvertionException>(() => value.AsDate());
         }
 
         [Fact]
@@ -127,10 +127,10 @@ namespace OneScript.Core.Tests
             Assert.True(value.DataType == DataType.GenericValue);
             Assert.True(value.AsString() == "");
 
-            Assert.Throws<RuntimeException>(() => value.AsNumber());
-            Assert.Throws<RuntimeException>(() => value.AsBoolean());
-            Assert.Throws<RuntimeException>(() => value.AsObject());
-            Assert.Throws<RuntimeException>(() => value.AsDate());
+            Assert.Throws<TypeConvertionException>(() => value.AsNumber());
+            Assert.Throws<TypeConvertionException>(() => value.AsBoolean());
+            Assert.Throws<TypeConvertionException>(() => value.AsObject());
+            Assert.Throws<TypeConvertionException>(() => value.AsDate());
         }
 
         [Fact]
@@ -144,10 +144,10 @@ namespace OneScript.Core.Tests
             Assert.True(typeValue.DataType == DataType.Type);
             Assert.True(typeValue.AsString() == "Строка");
 
-            Assert.Throws<RuntimeException>(() => typeValue.AsNumber());
-            Assert.Throws<RuntimeException>(() => typeValue.AsBoolean());
-            Assert.Throws<RuntimeException>(() => typeValue.AsObject());
-            Assert.Throws<RuntimeException>(() => typeValue.AsDate());
+            Assert.Throws<TypeConvertionException>(() => typeValue.AsNumber());
+            Assert.Throws<TypeConvertionException>(() => typeValue.AsBoolean());
+            Assert.Throws<TypeConvertionException>(() => typeValue.AsObject());
+            Assert.Throws<TypeConvertionException>(() => typeValue.AsDate());
 
         }
 

--- a/src/ScriptEngine/Machine/Contexts/AutoContext.cs
+++ b/src/ScriptEngine/Machine/Contexts/AutoContext.cs
@@ -77,28 +77,8 @@ namespace ScriptEngine.Machine.Contexts
             return _methods.GetMethodInfo(methodNumber);
         }
 
-        private void CheckIfCallIsPossible(int methodNumber, IValue[] arguments)
-        {
-            var methodInfo = _methods.GetMethodInfo(methodNumber);
-            if (!methodInfo.IsDeprecated)
-            {
-                return;
-            }
-            if (methodInfo.ThrowOnUseDeprecated)
-            {
-                throw RuntimeException.DeprecatedMethodCall(methodInfo.Name);
-            }
-            if (_warnedDeprecatedMethods.Contains(methodNumber))
-            {
-                return;
-            }
-            SystemLogger.Write($"ВНИМАНИЕ! Вызов устаревшего метода {methodInfo.Name}");
-            _warnedDeprecatedMethods.Add(methodNumber);
-        }
-
         public override void CallAsProcedure(int methodNumber, IValue[] arguments)
         {
-            CheckIfCallIsPossible(methodNumber, arguments);
             try
             {
                 _methods.GetMethod(methodNumber)((TInstance)this, arguments);
@@ -112,7 +92,6 @@ namespace ScriptEngine.Machine.Contexts
 
         public override void CallAsFunction(int methodNumber, IValue[] arguments, out IValue retValue)
         {
-            CheckIfCallIsPossible(methodNumber, arguments);
             try
             {
                 retValue = _methods.GetMethod(methodNumber)((TInstance)this, arguments);
@@ -126,6 +105,5 @@ namespace ScriptEngine.Machine.Contexts
 
         private static readonly ContextPropertyMapper<TInstance> _properties = new ContextPropertyMapper<TInstance>();
         private static readonly ContextMethodsMapper<TInstance> _methods = new ContextMethodsMapper<TInstance>();
-        private static readonly HashSet<int> _warnedDeprecatedMethods = new HashSet<int>();
     }
 }

--- a/src/ScriptEngine/Machine/MachineInstance.cs
+++ b/src/ScriptEngine/Machine/MachineInstance.cs
@@ -8,14 +8,11 @@ using ScriptEngine.Machine.Contexts;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using OneScript.Language;
 using OneScript.Language.LexicalAnalysis;
 using ScriptEngine.Compiler;
 using ScriptEngine.Environment;
 using ScriptEngine.Machine.Values;
-using System.Reflection;
-//using System.Runtime.Remoting.Contexts;
 
 namespace ScriptEngine.Machine
 {
@@ -1103,13 +1100,7 @@ namespace ScriptEngine.Machine
 
         private void ResolveProp(int arg)
         {
-            var objIValue = _operationStack.Pop();
-            if (objIValue.DataType != DataType.Object)
-            {
-                throw RuntimeException.ValueIsNotObjectException();
-            }
-
-            var context = objIValue.AsObject();
+            var context = _operationStack.Pop().AsObject();
             var propName = _module.Constants[arg].AsString();
             var propNum = context.FindProperty(propName);
 
@@ -1152,13 +1143,7 @@ namespace ScriptEngine.Machine
             var factArgs = PopArguments();
             var argCount = factArgs.Length;
 
-            var objIValue = _operationStack.Pop();
-            if (objIValue.DataType != DataType.Object)
-            {
-                throw RuntimeException.ValueIsNotObjectException();
-            }
-
-            context = objIValue.AsObject();
+            context = _operationStack.Pop().AsObject();
             var methodName = _module.Constants[arg].AsString();
             methodId = context.FindMethod(methodName);
     
@@ -1301,23 +1286,15 @@ namespace ScriptEngine.Machine
 
         private void PushIterator(int arg)
         {
-            var collection = _operationStack.Pop();
-            if (collection.DataType == DataType.Object)
+            var objValue = _operationStack.Pop().AsObject();
+            if (!(objValue is ICollectionContext collection))
             {
-                var context = collection.AsObject() as ICollectionContext;
-                if (context == null)
-                {
-                    throw RuntimeException.IteratorIsNotDefined();
-                }
+                throw RuntimeException.IteratorIsNotDefined();
+            }
 
-                var iterator = context.GetManagedIterator();
-                _currentFrame.LocalFrameStack.Push(iterator);
-                NextInstruction();
-            }
-            else
-            {
-                throw RuntimeException.ValueIsNotObjectException();
-            }
+            var iterator = collection.GetManagedIterator();
+            _currentFrame.LocalFrameStack.Push(iterator);
+            NextInstruction();
         }
 
         private void IteratorNext(int arg)

--- a/src/ScriptEngine/Machine/RuntimeExceptions.cs
+++ b/src/ScriptEngine/Machine/RuntimeExceptions.cs
@@ -86,7 +86,7 @@ namespace ScriptEngine.Machine
 
         public static RuntimeException ValueIsNotObjectException()
         {
-            return new RuntimeException("Значение не является значением объектного типа");
+            return new TypeConvertionException();
         }
 
         public static RuntimeException TooManyArgumentsPassed()
@@ -223,6 +223,10 @@ namespace ScriptEngine.Machine
     {
         public TypeConvertionException(string typename) 
             : base($"Преобразование к типу '{typename}' не поддерживается")
+        {
+        }
+        public TypeConvertionException() 
+            : base("Значение не является значением объектного типа")
         {
         }
     }


### PR DESCRIPTION
1. Поскольку подстановка значений параметров по умолчанию перенесена в `MachineInstance.PrepareArg()`, не нужно передавать их в формируемую лямбду вызова метода
2. При **каждом** вызове методов классов, унаследованных от `AutoContext` (а это _почти_ все объекты скипта) проверялся флаг `deprecated`. Для классов, которые _"почти"_ этот флаг, напротив, игнорировался.
Проверка вынесена к созданию делегата метода, но осталась в рантайме.