### PR TITLE
Исправлены окончания строк в баш скриптах crlf -> cr

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,4 @@
 *.sh    text eol=lf
+
+install/opm     text eol=lf
+install/oscript text eol=lf


### PR DESCRIPTION
При чекауте на сборочном агенте концы строк конвертятся в виндовый CRLF и в последствии скрипты становятся неработоспособными в *nix