### PR TITLE
v2: Передача в делегат (объект `Действие`) значений переменных

### DIFF
--- a/src/OneScript.StandardLibrary/DelegateAction.cs
+++ b/src/OneScript.StandardLibrary/DelegateAction.cs
@@ -42,7 +42,8 @@ namespace OneScript.StandardLibrary
 
         public DelegateAction(Func<BslValue[], BslValue> action)
         {
-            _action = parameters => (IValue)action(parameters.Cast<BslValue>().ToArray());
+            _action = parameters => action( parameters.Select(x=>x.GetRawValue())
+                .Cast<BslValue>().ToArray() );
         }
         
         public override bool DynamicMethodSignatures => true;


### PR DESCRIPTION
Падал тест `eratosfenes.os` на этой строке:
https://github.com/EvilBeaver/OneScript/blob/d39c6c73172579730eb06ec35d54100f60bc7aaf/tests/eratosthenes.os#L52
_Внешнее исключение (System.InvalidCastException): Unable to cast object of type 'OneScript.Contexts.Variable' to type 'OneScript.Values.BslValue'._