### PR TITLE
fix #1427: исправление раскрутки стека при исключении в Выполнить, с тестом

### DIFF
--- a/src/NUnitTests/ContextTests.cs
+++ b/src/NUnitTests/ContextTests.cs
@@ -565,6 +565,29 @@ namespace NUnitTests
             Assert.IsTrue(exceptionThrown, "Безнадёжно устаревший метод должен вызвать исключение");
         }
 
+        [Test]
+        public void TestICallExecuteWithException()
+        {
+            SystemLogger.SetWriter(this);
+            _messages.Clear();
+            var exceptionThrown = false;
+
+            try
+            {
+                host.RunTestString(
+                    @"Попытка
+	                    Выполнить(""Г=1/0"");
+                    Исключение
+                    КонецПопытки;");
+            }
+            catch
+            {
+                exceptionThrown = true;
+            }
+
+            Assert.IsFalse(exceptionThrown, "Перехваченное в Выполнить исключение не должно вызывать внешнее");
+        }
+
         public void Write(string text)
         {
             _messages.Add(text);

--- a/src/ScriptEngine/Machine/MachineInstance.cs
+++ b/src/ScriptEngine/Machine/MachineInstance.cs
@@ -1458,6 +1458,7 @@ namespace ScriptEngine.Machine
                 ModuleLoadIndex = _scopes.Count - 1,
                 Locals = new IVariable[method.Variables.Count],
                 InstructionPointer = 0,
+                IsReentrantCall = true
             };
             PushFrame(frame);
             CreateCurrentFrameLocals(method.Variables);


### PR DESCRIPTION
Исправление связано со способом раскрутки стека фреймов в `MachineInstance.ExecuteCode()`
Тест не может быть выполнен через testrunner.os - требуется модуль верхнего уровня.
Также закрывает #1425
