### PR TITLE
Новая обязательная зависимость

### DIFF
--- a/install/builders/deb/settings/control
+++ b/install/builders/deb/settings/control
@@ -10,6 +10,7 @@ Description: 1Script execution engine.
 Depends: mono-runtime,
   libmono-system-core4.0-cil | libmono-system-core4.5-cil,
   libmono-system4.0-cil | libmono-system4.5-cil,
+  libmono-system-data4.0-cil,
   libmono-corlib4.0-cil | libmono-corlib4.5-cil,
   libmono-i18n4.0-all | libmono-i18n4.5-all
 Recommends: mono-complete


### PR DESCRIPTION
без нее метод ПрочитатьДатуJSON() не работает на mono-runtime

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new dependency for enhanced data handling capabilities within the application, supporting improved functionality and possibly new features.

- **Enhancements**
  - Updated the dependency list to include `libmono-system-data4.0-cil`, ensuring essential library support for the 1Script execution engine.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->