### PR TITLE
Еще одна зависимость для deb

### DIFF
--- a/install/builders/deb/settings/control
+++ b/install/builders/deb/settings/control
@@ -10,6 +10,7 @@ Description: 1Script execution engine.
 Depends: mono-runtime,
   libmono-system-core4.0-cil | libmono-system-core4.5-cil,
   libmono-system4.0-cil | libmono-system4.5-cil,
+  libmono-system-runtime-serialization4.0-cil,
   libmono-system-data4.0-cil,
   libmono-corlib4.0-cil | libmono-corlib4.5-cil,
   libmono-i18n4.0-all | libmono-i18n4.5-all


### PR DESCRIPTION
Добавил еще одну зависимость. Без нее на mono-runtime точно не работает какой-то метод, но не помню какой именно, скриншотов не сохранилось.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new dependency for enhanced script execution capabilities related to runtime serialization.
- **Bug Fixes**
	- Resolved potential issues with the execution engine by ensuring all necessary libraries are included for proper functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->