### PR TITLE
Добавлена возможность запуска адаптера в режиме TCP сервера

### DIFF
--- a/src/VSCode.DebugAdapter/Program.cs
+++ b/src/VSCode.DebugAdapter/Program.cs
@@ -6,6 +6,7 @@ at http://mozilla.org/MPL/2.0/.
 ----------------------------------------------------------*/
 using System;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Net.Sockets;
 using Serilog;
@@ -16,7 +17,18 @@ namespace VSCode.DebugAdapter
     {
         static void Main(string[] args)
         {
-            StartSession(Console.OpenStandardInput(), Console.OpenStandardOutput());
+            if (args.Contains("--debug"))
+            {
+                var listener = TcpListener.Create(4711);
+                listener.Start();
+
+                using var client = listener.AcceptTcpClient();
+                using var stream = client.GetStream();
+
+                StartSession(stream, stream);
+            }
+            else
+                StartSession(Console.OpenStandardInput(), Console.OpenStandardOutput());
         }
         
         private static void StartSession(Stream input, Stream output)

--- a/src/VSCode.DebugAdapter/Program.cs
+++ b/src/VSCode.DebugAdapter/Program.cs
@@ -22,10 +22,9 @@ namespace VSCode.DebugAdapter
                 var listener = TcpListener.Create(4711);
                 listener.Start();
 
-                using var client = listener.AcceptTcpClient();
-                using var stream = client.GetStream();
-
-                StartSession(stream, stream);
+                using (var client = listener.AcceptTcpClient())
+                    using (var stream = client.GetStream())
+                        StartSession(stream, stream);
             }
             else
                 StartSession(Console.OpenStandardInput(), Console.OpenStandardOutput());

--- a/src/VSCode.DebugAdapter/Properties/launchSettings.json
+++ b/src/VSCode.DebugAdapter/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "VSCode.DebugAdapter": {
+      "commandName": "Project",
+      "commandLineArgs": "--debug"
+    }
+  }
+}

--- a/src/VSCode.DebugAdapter/VSCode.DebugAdapter.csproj
+++ b/src/VSCode.DebugAdapter/VSCode.DebugAdapter.csproj
@@ -9,7 +9,7 @@
     <Configurations>Debug;Release;LinuxDebug</Configurations>
     <AssemblyTitle>VSC debug adapter for 1Script</AssemblyTitle>
     <Platforms>AnyCPU</Platforms>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>11.0</LangVersion>
     <Version>1.7.0.0</Version>
     <FileVersion>1.7.0.0</FileVersion>
 	<GenerateRuntimeConfigDevFile>true</GenerateRuntimeConfigDevFile>

--- a/src/VSCode.DebugAdapter/VSCode.DebugAdapter.csproj
+++ b/src/VSCode.DebugAdapter/VSCode.DebugAdapter.csproj
@@ -9,7 +9,7 @@
     <Configurations>Debug;Release;LinuxDebug</Configurations>
     <AssemblyTitle>VSC debug adapter for 1Script</AssemblyTitle>
     <Platforms>AnyCPU</Platforms>
-    <LangVersion>11.0</LangVersion>
+    <LangVersion>7.3</LangVersion>
     <Version>1.7.0.0</Version>
     <FileVersion>1.7.0.0</FileVersion>
 	<GenerateRuntimeConfigDevFile>true</GenerateRuntimeConfigDevFile>


### PR DESCRIPTION
VSC позволяет подключаться к адаптеру по TCP, что позволяет отлаживать весь код адаптера, а не подключаться из IDE к процессу уже после инициализации. Для запуска адаптера в tcp режиме, необходимо передать аргумент --debug, порт отладки - 4711

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a debug mode that activates when the `--debug` argument is provided, allowing for enhanced debugging capabilities.
	- Added a new configuration profile for debugging in the `launchSettings.json` file.

- **Bug Fixes**
	- No specific bug fixes were noted in this release.

- **Refactor**
	- Updated the project to use a newer version of C# (from 7.3 to 11.0) for improved language features and performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->