### PR TITLE
Расширил описание для macos

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ OneScript позволяет создавать и выполнять текст
 
 - установить [homebrew](https://brew.sh/index_ru)
 - установить mono командой `brew install mono`
-- скачать [ovm](https://github.com/oscript-library/ovm/releases)
-- выполнить команду `mono ovm.exe install stable`
-- выполнить команду `mono ovm.exe use stable`
+- скачать [ovm](https://github.com/oscript-library/ovm/releases). Скачиваем именно `ovm.exe`
+- выполнить команду `mono path/to/ovm.exe install stable`. Чтобы корректно указать путь до `ovm.exe` можно перенести мышкой файл `ovm.exe`. Должно получится примерно так: `mono Users/username/Downloads/ovm.exe install stable`
+- выполнить команду `mono path/to/ovm.exe use stable`
 - перезапустить терминал
 
 #### Донастройка Self-Contained варианта поставки (не требующего инсталляции dotnet)

--- a/README.md
+++ b/README.md
@@ -42,8 +42,10 @@ OneScript позволяет создавать и выполнять текст
 
 - установить [homebrew](https://brew.sh/index_ru)
 - установить mono командой `brew install mono`
-- скачать [ovm](https://github.com/oscript-library/ovm/releases). Скачиваем именно `ovm.exe`
-- выполнить команду `mono path/to/ovm.exe install stable`. Чтобы корректно указать путь до `ovm.exe` можно перенести мышкой файл `ovm.exe`. Должно получится примерно так: `mono Users/username/Downloads/ovm.exe install stable`
+- скачать [ovm](https://github.com/oscript-library/ovm/releases). Скачать файл `ovm.exe` (несмотря на то что расширение .exe он запустится на MacOS)
+- выполнить команду `mono path/to/ovm.exe install stable`. 
+
+    Совет: *Чтобы корректно указать путь до `ovm.exe` перенесите мышкой файл `ovm.exe` в терминал. Должно получится примерно так: `mono Users/username/Downloads/ovm.exe install stable`*
 - выполнить команду `mono path/to/ovm.exe use stable`
 - перезапустить терминал
 

--- a/README.md
+++ b/README.md
@@ -42,10 +42,10 @@ OneScript позволяет создавать и выполнять текст
 
 - установить [homebrew](https://brew.sh/index_ru)
 - установить mono командой `brew install mono`
-- скачать [ovm](https://github.com/oscript-library/ovm/releases). Скачать файл `ovm.exe` (несмотря на то что расширение .exe он запустится на MacOS)
-- выполнить команду `mono path/to/ovm.exe install stable`. 
+- скачать [ovm](https://github.com/oscript-library/ovm/releases). Скачать файл `ovm.exe` (несмотря на расширение .exe он сработает на MacOS)
+- выполнить команду `mono path/to/ovm.exe install stable`
 
-    Совет: *Чтобы корректно указать путь до `ovm.exe` перенесите мышкой файл `ovm.exe` в терминал. Должно получится примерно так: `mono Users/username/Downloads/ovm.exe install stable`*
+    *Совет: Чтобы корректно указать путь до `ovm.exe` перенесите мышкой файл `ovm.exe` в терминал. Пример полной команды: `mono Users/username/Downloads/ovm.exe install stable`*
 - выполнить команду `mono path/to/ovm.exe use stable`
 - перезапустить терминал
 


### PR DESCRIPTION
Столкнулся с проблемами при установке oneScript на macOS. Решил их и дописал в установщик.
Если нужно в другом формате или сначала создать issue, то готов это проделать.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Enhanced installation instructions for MacOS, clarifying steps for downloading and executing the `ovm.exe` file.
	- Added a tip for specifying the path by dragging the file into the terminal.
	- Improved clarity and specificity in the manual local build instructions.
	- Minor formatting adjustments throughout the `README.md` for better readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->