### PR TITLE
fix #1464: если в атрибуте не указан алиас, то им будет имя метода

### DIFF
--- a/src/OneScript.Core/Contexts/ClassBuilder.cs
+++ b/src/OneScript.Core/Contexts/ClassBuilder.cs
@@ -66,7 +66,7 @@ namespace OneScript.Contexts
             }
             else
             {
-                var markup = new ContextMethodAttribute(nativeMethod.Name);
+                var markup = new ContextMethodAttribute(nativeMethod.Name, null); // no alias
                 _methods.Add(new ContextMethodInfo(nativeMethod, markup));
             }
 

--- a/src/OneScript.Core/Contexts/ContextMethodAttribute.cs
+++ b/src/OneScript.Core/Contexts/ContextMethodAttribute.cs
@@ -6,6 +6,7 @@ at http://mozilla.org/MPL/2.0/.
 ----------------------------------------------------------*/
 
 using System;
+using System.Runtime.CompilerServices;
 using OneScript.Commons;
 
 namespace OneScript.Contexts
@@ -16,40 +17,27 @@ namespace OneScript.Contexts
         private readonly string _name;
         private readonly string _alias;
 
-        public ContextMethodAttribute(string name, string alias = null)
+        public ContextMethodAttribute(string name, string alias) 
         {
             if (!Utils.IsValidIdentifier(name))
-                throw new ArgumentException("Name must be a valid identifier");
+                throw new ArgumentException($"Name '{name}' must be a valid identifier");
 
             if (!string.IsNullOrEmpty(alias) && !Utils.IsValidIdentifier(alias))
-                throw new ArgumentException("Alias must be a valid identifier");
+                throw new ArgumentException($"Alias '{alias}' must be a valid identifier");
 
             _name = name;
             _alias = alias;
         }
 
-        public string GetName()
+        public ContextMethodAttribute(string name, string _ = null, 
+            [CallerMemberName] string nativeMethodName = null)
+        : this(name, nativeMethodName)
         {
-            return _name;
         }
 
-        public string GetAlias()
-        {
-            return _alias;
-        }
+        public string GetName() => _name;
 
-        public string GetAlias(string nativeMethodName)
-        {
-            if (!string.IsNullOrEmpty(_alias))
-            {
-                return _alias;
-            }
-            if (!IsDeprecated)
-            {
-                return nativeMethodName;
-            }
-            return null;
-        }
+        public string GetAlias() => _alias;
 
         public bool IsDeprecated { get; set; }
 

--- a/src/ScriptEngine/Machine/Contexts/ContextMethodMapper.cs
+++ b/src/ScriptEngine/Machine/Contexts/ContextMethodMapper.cs
@@ -163,7 +163,7 @@ namespace ScriptEngine.Machine.Contexts
                 scriptMethInfo.IsDeprecated = binding.IsDeprecated;
                 scriptMethInfo.ThrowOnUseDeprecated = binding.ThrowOnUse;
                 scriptMethInfo.Name = binding.GetName();
-                scriptMethInfo.Alias = binding.GetAlias(target.Name);
+                scriptMethInfo.Alias = binding.GetAlias();
 
                 scriptMethInfo.Params = paramDefs;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error reporting in the `ContextMethodAttribute` class constructor for invalid identifiers.
	- Added a new constructor overload in `ContextMethodAttribute` for improved flexibility.

- **Bug Fixes**
	- Updated alias retrieval logic in the `CreateMetadata` method for better accuracy.

- **Refactor**
	- Simplified method implementations in `ContextMethodAttribute` for cleaner code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->