### PR TITLE
Исправление #1471

### DIFF
--- a/src/OneScript.StandardLibrary/Net/TCPClient.cs
+++ b/src/OneScript.StandardLibrary/Net/TCPClient.cs
@@ -81,7 +81,11 @@ namespace OneScript.StandardLibrary.Net
                 int numberOfBytesRead = source.Read(readBuffer, 0, portion);
                 ms.Write(readBuffer, 0, numberOfBytesRead);
                 if (useLimit)
-                    limit -= numberOfBytesRead;
+                {
+					limit -= numberOfBytesRead;
+                    if (limit <= 0)
+                        break;
+                }
             } while (source.DataAvailable);
             
             if(ms.Length > 0)

--- a/src/OneScript.StandardLibrary/Net/TCPClient.cs
+++ b/src/OneScript.StandardLibrary/Net/TCPClient.cs
@@ -82,7 +82,7 @@ namespace OneScript.StandardLibrary.Net
                 ms.Write(readBuffer, 0, numberOfBytesRead);
                 if (useLimit)
                 {
-					limit -= numberOfBytesRead;
+                    limit -= numberOfBytesRead;
                     if (limit <= 0)
                         break;
                 }


### PR DESCRIPTION
Если при вызове метода был установлен лимит и размер входящих данных был больше лимита, то на вход Read соединения подается буфер нулевого размера 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the precision of data reading operations by implementing a limit check in the reading loop of the TCP client.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->