### PR TITLE
v2 fix #1409: работа ЧтенияДанных из ДвоичныхДанных большого размера

### DIFF
--- a/src/OneScript.StandardLibrary/Binary/BackingTemporaryFile.cs
+++ b/src/OneScript.StandardLibrary/Binary/BackingTemporaryFile.cs
@@ -8,7 +8,6 @@ at http://mozilla.org/MPL/2.0/.
 using System;
 using System.IO;
 using Microsoft.Win32.SafeHandles;
-using ScriptEngine;
 
 namespace OneScript.StandardLibrary.Binary
 {
@@ -57,7 +56,7 @@ namespace OneScript.StandardLibrary.Binary
 
         public Stream OpenReadStream()
         {
-            return new FileStream(_backingFilePath, FileMode.Open, FileAccess.Read, FileShare.Read);
+            return new FileStream(_backingFilePath, FileMode.Open, FileAccess.Read, FileShare.Read | FileShare.Delete);
         }
         
         private void Init(Stream source)

--- a/src/OneScript.StandardLibrary/Binary/DataReader.cs
+++ b/src/OneScript.StandardLibrary/Binary/DataReader.cs
@@ -70,24 +70,23 @@ namespace OneScript.StandardLibrary.Binary
         [ScriptConstructor(Name = "На основании двоичных данных или имени файла")]
         public static DataReader Constructor(IValue dataSource, IValue textEncoding = null, ByteOrderEnum? byteOrder = null, string lineSplitter = "\n", string convertibleSplitterOfLines = null)
         {
+            Stream stream;
             if (dataSource.SystemType == BasicTypes.String)
             {
-                var stream = new FileStream(dataSource.AsString(), FileMode.Open, FileAccess.Read, FileShare.Read);
-                return new DataReader(stream, textEncoding, byteOrder, lineSplitter, convertibleSplitterOfLines);
+                stream = new FileStream(dataSource.AsString(), FileMode.Open, FileAccess.Read, FileShare.Read);
             }
             else
             {
-                var obj = dataSource.AsObject();
-                Stream stream;
-                if (obj is BinaryDataContext)
-                    stream = ((BinaryDataContext)obj).GetStream();
-                else if (obj is IStreamWrapper)
-                    stream = ((IStreamWrapper) obj).GetUnderlyingStream();
-                else
-                    throw RuntimeException.InvalidArgumentType("dataSource");
+                stream = dataSource.AsObject() switch
+                {
+                    BinaryDataContext binaryData => binaryData.GetStream(),
+                    IStreamWrapper wrapper => wrapper.GetUnderlyingStream(),
 
-                return new DataReader(stream, textEncoding, byteOrder, lineSplitter, convertibleSplitterOfLines);
+                    _ => throw RuntimeException.InvalidArgumentType("dataSource")
+                };
             }
+
+            return new DataReader(stream, textEncoding, byteOrder, lineSplitter, convertibleSplitterOfLines);
         }
         
         /// <summary>


### PR DESCRIPTION
Ранее падало на
```bsl
ДвоичныеДанные = Новый ДвоичныеДанные("MoreThan50MiB.file"); 
ЧтениеДанных = Новый ЧтениеДанных(ДвоичныеДанные);
```
_Внешнее исключение (System.IO.IOException): The process cannot access the file 'tmpE038.tmp' because it is being used by another process._

Причину см.: https://github.com/dotnet/runtime/issues/91484#issuecomment-1706855835


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Adjusted file stream handling to support concurrent deletion during read operations.
  - Streamlined data reading logic with a more concise control flow for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->