### PR TITLE
v2 fix #1493: объект Действие не ломает отображение переменных в отладке

### DIFF
--- a/src/ScriptEngine/Machine/Contexts/ContextIValueImpl.cs
+++ b/src/ScriptEngine/Machine/Contexts/ContextIValueImpl.cs
@@ -136,21 +136,15 @@ namespace ScriptEngine.Machine.Contexts
             throw new NotImplementedException();
         }
 
-        public virtual int GetPropCount()
-        {
-            throw new NotImplementedException();
-        }
+        public virtual int GetPropCount() => 0;
 
         public virtual string GetPropName(int propNum)
         {
             throw new NotImplementedException();
         }
 
-        public virtual int GetMethodsCount()
-        {
-            throw new NotImplementedException();
-        }
-
+        public virtual int GetMethodsCount() => 0;
+ 
         public virtual int GetMethodNumber(string name)
         {
             throw RuntimeException.MethodNotFoundException(name);


### PR DESCRIPTION
Падало здесь:
https://github.com/EvilBeaver/OneScript/blob/7a3239d3086a753780f82d53b352f7a7f41da91e/src/OneScript.DebugServices/DefaultVariableVisualizer.cs#L109
Возврат дефолтного (нулевого) значения вынесен в базовый класс.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Adjusted internal functionality to return default numeric values instead of triggering errors. This update improves application stability and prevents unexpected exceptions during operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->