### PR TITLE
v2 к #1295: работа параметра runtime.default

### DIFF
--- a/src/ScriptEngine/Compiler/CompilerBackendSelector.cs
+++ b/src/ScriptEngine/Compiler/CompilerBackendSelector.cs
@@ -17,11 +17,10 @@ namespace ScriptEngine.Compiler
     public class CompilerBackendSelector : BslSyntaxWalker
     {
         private bool _isNative;
-        private bool _isNativeDefault;
 
         public CompilerBackendSelector(OneScriptCoreOptions options)
         {
-            _isNativeDefault = options.UseNativeAsDefaultRuntime;
+            _isNative = options.UseNativeAsDefaultRuntime;
         }
         
         public Func<ICompilerBackend> StackBackendInitializer { get; set; }
@@ -50,10 +49,6 @@ namespace ScriptEngine.Compiler
                          StringComparison.CurrentCultureIgnoreCase))
             {
                 _isNative = false;
-            }
-            else
-            {
-                _isNative = _isNativeDefault;
             }
         }
 


### PR DESCRIPTION
Установка параметра `runtime.default=native` не срабатывала, если компилируемый модуль не содержал никаких аннотаций.
В этом случае из `VisitModule()` не вызывался `VisitModuleAnnotation()`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Streamlined module configuration: The runtime behavior is now determined solely by explicit settings from module annotations, removing fallback defaults. This update provides a more predictable and streamlined execution experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->