### PR TITLE
Чтение всех параметров конфигурации Kestrel из appsettings.json

### DIFF
--- a/src/OneScript.Web.Server/WebServer.cs
+++ b/src/OneScript.Web.Server/WebServer.cs
@@ -16,6 +16,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Diagnostics;
 using ExecutionContext = ScriptEngine.Machine.ExecutionContext;
+using Microsoft.Extensions.Configuration;
 
 namespace OneScript.Web.Server
 {
@@ -91,6 +92,10 @@ namespace OneScript.Web.Server
             var builder = WebApplication.CreateBuilder(appOptions);
             builder.WebHost.ConfigureKestrel(options =>
             {
+                var kestrelSection = builder.Configuration.GetSection("Kestrel");
+                options.Configure(kestrelSection);
+                kestrelSection.Bind(options);
+
                 options.AllowSynchronousIO = true;
                 options.ListenAnyIP(Port);
             });


### PR DESCRIPTION
Closes #1519 

Раннее настройки из `appsettings.json` читались, но некоторые настройки (в т.ч. раздел `Kestrel.Limits`) не применялись для Kestrel. Данным PR эта проблема решается.

Более подробно эта проблема обсуждалась в [этом треде](https://github.com/dotnet/aspnetcore/issues/4765). А решение было написано в [комментарии](https://github.com/dotnet/aspnetcore/issues/4765#issuecomment-1790751061).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the web server’s configuration capability by enabling dynamic loading and binding of settings from the application’s configuration file. This results in greater flexibility and streamlined updates to server behavior during deployments, ensuring a smoother, more responsive operational experience. The improvement also streamlines administration by permitting configuration adjustments without altering code, supporting evolving requirements and simplifying maintenance across diverse environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->