### PR TITLE
Дополнение и исправление английских вариантов лексем

### DIFF
--- a/src/OneScript.Core/Contexts/Enums/EnumerationTypeAttribute.cs
+++ b/src/OneScript.Core/Contexts/Enums/EnumerationTypeAttribute.cs
@@ -12,7 +12,7 @@ namespace OneScript.Contexts.Enums
     /// <summary>
     /// Атрибут для простых перечислений, являющихся обычными Clr-перечислениями
     /// </summary>
-	[AttributeUsage(AttributeTargets.Enum)]
+	[AttributeUsage(AttributeTargets.Enum, AllowMultiple = true)]
     public class EnumerationTypeAttribute : Attribute, IEnumMetadataProvider
     {
         public EnumerationTypeAttribute (string name, string alias = null, bool createProperty = true)

--- a/src/OneScript.Core/Contexts/Enums/EnumerationTypeAttribute.cs
+++ b/src/OneScript.Core/Contexts/Enums/EnumerationTypeAttribute.cs
@@ -29,5 +29,6 @@ namespace OneScript.Contexts.Enums
 		public string TypeUUID { get; set; }
 		
 		public string ValueTypeUUID { get; set; }
+		public bool IsDeprecated { get; set; }
     }
 }

--- a/src/OneScript.Core/Contexts/Enums/EnumerationTypeAttribute.cs
+++ b/src/OneScript.Core/Contexts/Enums/EnumerationTypeAttribute.cs
@@ -12,7 +12,7 @@ namespace OneScript.Contexts.Enums
     /// <summary>
     /// Атрибут для простых перечислений, являющихся обычными Clr-перечислениями
     /// </summary>
-	[AttributeUsage(AttributeTargets.Enum, AllowMultiple = true)]
+	[AttributeUsage(AttributeTargets.Enum)]
     public class EnumerationTypeAttribute : Attribute, IEnumMetadataProvider
     {
         public EnumerationTypeAttribute (string name, string alias = null, bool createProperty = true)
@@ -29,6 +29,5 @@ namespace OneScript.Contexts.Enums
 		public string TypeUUID { get; set; }
 		
 		public string ValueTypeUUID { get; set; }
-		public bool IsDeprecated { get; set; }
     }
 }

--- a/src/OneScript.StandardLibrary/Binary/GlobalBinaryData.cs
+++ b/src/OneScript.StandardLibrary/Binary/GlobalBinaryData.cs
@@ -183,7 +183,7 @@ namespace OneScript.StandardLibrary.Binary
         /// <param name="data">Объект типа ДвоичныеДанные.</param>
         /// <param name="size">Размер одной части данных.</param>
         /// <returns>Массив объектов типа ДвоичныеДанные.</returns>
-        [ContextMethod("РазделитьДвоичныеДанные")]
+        [ContextMethod("РазделитьДвоичныеДанные", "SplitBinaryData")]
         public ArrayImpl SplitBinaryData(BinaryDataContext data, long size)
         {
             CheckAndThrowIfNull(data, 1, nameof(data));
@@ -225,7 +225,7 @@ namespace OneScript.StandardLibrary.Binary
         /// <param name="encoding">Кодировка текста</param>
         /// <param name="addBOM">Определяет, будет ли добавлена метка порядка байт (BOM) кодировки текста в начало данных.</param>
         /// <returns>Тип: ДвоичныеДанные.</returns>
-        [ContextMethod("ПолучитьДвоичныеДанныеИзСтроки")]
+        [ContextMethod("ПолучитьДвоичныеДанныеИзСтроки", "GetBinaryDataFromString")]
         public BinaryDataContext GetBinaryDataFromString(string str, IValue encoding = null, bool addBOM = false)
         {
             // Получаем кодировку
@@ -254,7 +254,7 @@ namespace OneScript.StandardLibrary.Binary
         /// <param name="encoding">Кодировка текста</param>
         /// <param name="addBOM">Определяет, будет ли добавлена метка порядка байт (BOM) кодировки текста в начало данных.</param>
         /// <returns>Тип: БуферДвоичныхДанных.</returns>
-        [ContextMethod("ПолучитьБуферДвоичныхДанныхИзСтроки")]
+        [ContextMethod("ПолучитьБуферДвоичныхДанныхИзСтроки", "GetBinaryDataBufferFromString")]
         public BinaryDataBuffer GetBinaryDataBufferFromString(string str, IValue encoding = null, bool addBOM = false)
         {
             var enc = (encoding != null)? TextEncodingEnum.GetEncoding(encoding, addBOM) : Encoding.UTF8;
@@ -268,7 +268,7 @@ namespace OneScript.StandardLibrary.Binary
         /// <param name="data">Двоичные данные, которые требуется преобразовать в строку.</param>
         /// <param name="encoding">Кодировка текста</param>
         /// <returns>Тип: Строка.</returns>
-        [ContextMethod("ПолучитьСтрокуИзДвоичныхДанных")]
+        [ContextMethod("ПолучитьСтрокуИзДвоичныхДанных", "GetStringFromBinaryData")]
         public string GetStringFromBinaryData(BinaryDataContext data, IValue encoding = null)
         {
             CheckAndThrowIfNull(data, 1, nameof(data));
@@ -286,7 +286,7 @@ namespace OneScript.StandardLibrary.Binary
         /// <param name="buffer">Буфер двоичных данных, который требуется преобразовать в строку.</param>
         /// <param name="encoding">Кодировка текста</param>
         /// <returns>Тип: Строка.</returns>
-        [ContextMethod("ПолучитьСтрокуИзБуфераДвоичныхДанных")]
+        [ContextMethod("ПолучитьСтрокуИзБуфераДвоичныхДанных", "GetStringFromBinaryDataBuffer")]
         public string GetStringFromBinaryDataBuffer(BinaryDataBuffer buffer, IValue encoding = null)
         {
             CheckAndThrowIfNull(buffer, 1, nameof(buffer));
@@ -301,7 +301,7 @@ namespace OneScript.StandardLibrary.Binary
         /// </summary>
         /// <param name="str">Строка в формате Base64.</param>
         /// <returns>Тип: ДвоичныеДанные.</returns>
-        [ContextMethod("ПолучитьДвоичныеДанныеИзBase64Строки")]
+        [ContextMethod("ПолучитьДвоичныеДанныеИзBase64Строки", "GetBinaryDataFromBase64String")]
         public BinaryDataContext GetBinaryDataFromBase64String(string str)
         {
             try
@@ -319,7 +319,7 @@ namespace OneScript.StandardLibrary.Binary
         /// </summary>
         /// <param name="str">Строка в формате Base64.</param>
         /// <returns>Тип: ДвоичныеДанные.</returns>
-        [ContextMethod("ПолучитьБуферДвоичныхДанныхИзBase64Строки")]
+        [ContextMethod("ПолучитьБуферДвоичныхДанныхИзBase64Строки", "GetBinaryDataBufferFromBase64String")]
         public BinaryDataBuffer GetBinaryDataBufferFromBase64String(string str)
         {
             try
@@ -339,7 +339,7 @@ namespace OneScript.StandardLibrary.Binary
         /// </summary>
         /// <param name="data">Двоичные данные.</param>
         /// <returns>Тип: Строка.</returns>
-        [ContextMethod("ПолучитьBase64СтрокуИзДвоичныхДанных")]
+        [ContextMethod("ПолучитьBase64СтрокуИзДвоичныхДанных", "GetBase64StringFromBinaryData")]
         public string GetBase64StringFromBinaryData(BinaryDataContext data)
         {
             CheckAndThrowIfNull(data, 1, nameof(data));
@@ -354,7 +354,7 @@ namespace OneScript.StandardLibrary.Binary
         /// </summary>
         /// <param name="buffer">Буфер двоичных данных.</param>
         /// <returns>Тип: Строка.</returns>
-        [ContextMethod("ПолучитьBase64СтрокуИзБуфераДвоичныхДанных")]
+        [ContextMethod("ПолучитьBase64СтрокуИзБуфераДвоичныхДанных", "GetBase64StringFromBinaryDataBuffer")]
         public string GetBase64StringFromBinaryDataBuffer(BinaryDataBuffer buffer)
         {
             CheckAndThrowIfNull(buffer);
@@ -367,7 +367,7 @@ namespace OneScript.StandardLibrary.Binary
         /// </summary>
         /// <param name="data">Двоичные данные, закодированные по методу Base64.</param>
         /// <returns>Тип: ДвоичныеДанные.</returns>
-        [ContextMethod("ПолучитьДвоичныеДанныеИзBase64ДвоичныхДанных")]
+        [ContextMethod("ПолучитьДвоичныеДанныеИзBase64ДвоичныхДанных", "GetBinaryDataFromBase64BinaryData")]
         public BinaryDataContext GetBinaryDataFromBase64BinaryData(BinaryDataContext data)
         {
             CheckAndThrowIfNull(data);
@@ -389,7 +389,7 @@ namespace OneScript.StandardLibrary.Binary
         /// </summary>
         /// <param name="buffer">Буфер двоичных данных.</param>
         /// <returns>Тип: ДвоичныеДанные.</returns>
-        [ContextMethod("ПолучитьБуферДвоичныхДанныхИзBase64БуфераДвоичныхДанных")]
+        [ContextMethod("ПолучитьБуферДвоичныхДанныхИзBase64БуфераДвоичныхДанных", "GetBinaryDataBufferFromBase64BinaryDataBuffer")]
         public BinaryDataBuffer GetBinaryDataBufferFromBase64BinaryDataBuffer(BinaryDataBuffer buffer)
         {
             CheckAndThrowIfNull(buffer);
@@ -413,7 +413,7 @@ namespace OneScript.StandardLibrary.Binary
         /// </summary>
         /// <param name="data">Двоичные данные.</param>
         /// <returns>Тип: ДвоичныеДанные.</returns>
-        [ContextMethod("ПолучитьBase64ДвоичныеДанныеИзДвоичныхДанных")]
+        [ContextMethod("ПолучитьBase64ДвоичныеДанныеИзДвоичныхДанных", "GetBase64BinaryDataFromBinaryData")]
         public BinaryDataContext GetBase64BinaryDataFromBinaryData(BinaryDataContext data)
         {
             CheckAndThrowIfNull(data);
@@ -429,7 +429,7 @@ namespace OneScript.StandardLibrary.Binary
         /// </summary>
         /// <param name="buffer">Буфер двоичных данных.</param>
         /// <returns>Тип: БуферДвоичныхДанных.</returns>
-        [ContextMethod("ПолучитьBase64БуферДвоичныхДанныхИзБуфераДвоичныхДанных")]
+        [ContextMethod("ПолучитьBase64БуферДвоичныхДанныхИзБуфераДвоичныхДанных", "GetBase64BinaryDataBufferFromBinaryDataBuffer")]
         public BinaryDataBuffer GetBase64BinaryDataBufferFromBinaryDataBuffer(BinaryDataBuffer buffer)
         {
             CheckAndThrowIfNull(buffer);
@@ -443,7 +443,7 @@ namespace OneScript.StandardLibrary.Binary
         /// </summary>
         /// <param name="hex">Строка в формате Base 16 (Hex).</param>
         /// <returns>Тип: ДвоичныеДанные.</returns>
-        [ContextMethod("ПолучитьДвоичныеДанныеИзHexСтроки")]
+        [ContextMethod("ПолучитьДвоичныеДанныеИзHexСтроки", "GetBinaryDataFromHexString")]
         public BinaryDataContext GetBinaryDataFromHexString(string hex)
         {
             return new BinaryDataContext(HexStringToByteArray(hex));
@@ -454,7 +454,7 @@ namespace OneScript.StandardLibrary.Binary
         /// </summary>
         /// <param name="hex">Строка в формате Base 16 (Hex).</param>
         /// <returns>Тип: БуферДвоичныхДанных.</returns>
-        [ContextMethod("ПолучитьБуферДвоичныхДанныхИзHexСтроки")]
+        [ContextMethod("ПолучитьБуферДвоичныхДанныхИзHexСтроки", "GetBinaryDataBufferFromHexString")]
         public BinaryDataBuffer GetBinaryDataBufferFromHexString(string hex)
         {
             return new BinaryDataBuffer(HexStringToByteArray(hex));
@@ -465,7 +465,7 @@ namespace OneScript.StandardLibrary.Binary
         /// </summary>
         /// <param name="data">Двоичные данные.</param>
         /// <returns>Тип: Строка.</returns>
-        [ContextMethod("ПолучитьHexСтрокуИзДвоичныхДанных")]
+        [ContextMethod("ПолучитьHexСтрокуИзДвоичныхДанных", "GetHexStringFromBinaryData")]
         public string GetHexStringFromBinaryData(BinaryDataContext data)
         {
             CheckAndThrowIfNull(data);
@@ -478,7 +478,7 @@ namespace OneScript.StandardLibrary.Binary
         /// </summary>
         /// <param name="buffer">Буфер двоичных данных.</param>
         /// <returns>Тип: Строка.</returns>
-        [ContextMethod("ПолучитьHexСтрокуИзБуфераДвоичныхДанных")]
+        [ContextMethod("ПолучитьHexСтрокуИзБуфераДвоичныхДанных", "GetHexStringFromBinaryDataBuffer")]
         public string GetHexStringFromBinaryDataBuffer(BinaryDataBuffer buffer)
         {
             CheckAndThrowIfNull(buffer); 
@@ -491,7 +491,7 @@ namespace OneScript.StandardLibrary.Binary
         /// </summary>
         /// <param name="data">Двоичные данные в формате Base 16 (Hex).</param>
         /// <returns>Тип: ДвоичныеДанные. </returns>
-        [ContextMethod("ПолучитьДвоичныеДанныеИзHexДвоичныхДанных")]
+        [ContextMethod("ПолучитьДвоичныеДанныеИзHexДвоичныхДанных", "GetBinaryDataFromHexBinaryData")]
         public BinaryDataContext GetBinaryDataFromHexBinaryData(BinaryDataContext data)
         {
             CheckAndThrowIfNull(data);
@@ -504,7 +504,7 @@ namespace OneScript.StandardLibrary.Binary
         /// </summary>
         /// <param name="buffer">Буфер двоичных данных в формате Base 16 (Hex).</param>
         /// <returns>Тип: БуферДвоичныхДанных.</returns>
-        [ContextMethod("ПолучитьБуферДвоичныхДанныхИзHexБуфераДвоичныхДанных")]
+        [ContextMethod("ПолучитьБуферДвоичныхДанныхИзHexБуфераДвоичныхДанных", "GetBinaryDataBufferFromHexBinaryDataBuffer")]
         public BinaryDataBuffer GetBinaryDataBufferFromHexBinaryDataBuffer(BinaryDataBuffer buffer)
         {
             CheckAndThrowIfNull(buffer); 
@@ -517,7 +517,7 @@ namespace OneScript.StandardLibrary.Binary
         /// </summary>
         /// <param name="data">Двоичные данные.</param>
         /// <returns>Тип: ДвоичныеДанные. </returns>
-        [ContextMethod("ПолучитьHexДвоичныеДанныеИзДвоичныхДанных")]
+        [ContextMethod("ПолучитьHexДвоичныеДанныеИзДвоичныхДанных", "GetHexBinaryDataFromBinaryData")]
         public BinaryDataContext GetHexBinaryDataFromBinaryData(BinaryDataContext data)
         {
             var str = GetHexStringFromBinaryData(data);
@@ -529,7 +529,7 @@ namespace OneScript.StandardLibrary.Binary
         /// </summary>
         /// <param name="buffer">Буфер двоичных данных.</param>
         /// <returns>Тип: БуферДвоичныхДанных.</returns>
-        [ContextMethod("ПолучитьHexБуферДвоичныхДанныхИзБуфераДвоичныхДанных")]
+        [ContextMethod("ПолучитьHexБуферДвоичныхДанныхИзБуфераДвоичныхДанных", "GetHexBinaryDataBufferFromBinaryDataBuffer")]
         public BinaryDataBuffer GetHexBinaryDataBufferFromBinaryDataBuffer(BinaryDataBuffer buffer)
         {
             var str = GetHexStringFromBinaryDataBuffer(buffer);
@@ -541,7 +541,7 @@ namespace OneScript.StandardLibrary.Binary
         /// </summary>
         /// <param name="data">Двоичные данные.</param>
         /// <returns>Тип: БуферДвоичныхДанных.</returns>
-        [ContextMethod("ПолучитьБуферДвоичныхДанныхИзДвоичныхДанных")]
+        [ContextMethod("ПолучитьБуферДвоичныхДанныхИзДвоичныхДанных", "GetBinaryDataBufferFromBinaryData")]
         public BinaryDataBuffer GetBinaryDataBufferFromBinaryData(BinaryDataContext data)
         {
             CheckAndThrowIfNull(data);
@@ -554,7 +554,7 @@ namespace OneScript.StandardLibrary.Binary
         /// </summary>
         /// <param name="buffer">Буфер двоичных данных.</param>
         /// <returns>Тип: ДвоичныеДанные.</returns>
-        [ContextMethod("ПолучитьДвоичныеДанныеИзБуфераДвоичныхДанных")]
+        [ContextMethod("ПолучитьДвоичныеДанныеИзБуфераДвоичныхДанных", "GetBinaryDataFromBinaryDataBuffer")]
         public BinaryDataContext GetBinaryDataFromBinaryDataBuffer(BinaryDataBuffer buffer)
         {
             CheckAndThrowIfNull(buffer);

--- a/src/OneScript.StandardLibrary/Binary/MemoryStreamContext.cs
+++ b/src/OneScript.StandardLibrary/Binary/MemoryStreamContext.cs
@@ -306,7 +306,7 @@ namespace OneScript.StandardLibrary.Binary
         /// закрывает поток и возвращает результат в виде двоичных данных
         /// </summary>
         /// <returns></returns>
-        [ContextMethod("ЗакрытьИПолучитьДвоичныеДанные")]
+        [ContextMethod("ЗакрытьИПолучитьДвоичныеДанные", "CloseAndGetBinaryData")]
         public BinaryDataContext CloseAndGetBinaryData()
         {
             byte[] bytes;

--- a/src/OneScript.StandardLibrary/Binary/StreamEnums.cs
+++ b/src/OneScript.StandardLibrary/Binary/StreamEnums.cs
@@ -37,7 +37,7 @@ namespace OneScript.StandardLibrary.Binary
         ReadAndWrite
     }
 
-    [ContextMethod("StreamPosition", IsDeprecated = true)]
+    [EnumerationType("StreamPosition", IsDeprecated = true)]
     [EnumerationType("ПозицияВПотоке", "PositionInStream")]
     public enum StreamPositionEnum
     {

--- a/src/OneScript.StandardLibrary/Binary/StreamEnums.cs
+++ b/src/OneScript.StandardLibrary/Binary/StreamEnums.cs
@@ -37,8 +37,7 @@ namespace OneScript.StandardLibrary.Binary
         ReadAndWrite
     }
 
-    [EnumerationType("StreamPosition", IsDeprecated = true)]
-    [EnumerationType("ПозицияВПотоке", "PositionInStream")]
+    [EnumerationType("ПозицияВПотоке", "StreamPosition")]
     public enum StreamPositionEnum
     {
         [EnumValue("Начало", "Begin")]

--- a/src/OneScript.StandardLibrary/Binary/StreamEnums.cs
+++ b/src/OneScript.StandardLibrary/Binary/StreamEnums.cs
@@ -12,39 +12,40 @@ namespace OneScript.StandardLibrary.Binary
     [EnumerationType("РежимОткрытияФайла", "FileOpenMode")]
     public enum FileOpenModeEnum
     {
-        [EnumValue("Дописать")]
+        [EnumValue("Дописать", "Append")]
         Append,
-        [EnumValue("Обрезать")]
+        [EnumValue("Обрезать", "Truncate")]
         Truncate,
-        [EnumValue("Открыть")]
+        [EnumValue("Открыть", "Open")]
         Open,
-        [EnumValue("ОткрытьИлиСоздать")]
+        [EnumValue("ОткрытьИлиСоздать", "OpenOrCreate")]
         OpenOrCreate,
-        [EnumValue("Создать")]
+        [EnumValue("Создать", "Create")]
         Create,
-        [EnumValue("СоздатьНовый")]
+        [EnumValue("СоздатьНовый", "CreateNew")]
         CreateNew
     }
 
     [EnumerationType("ДоступКФайлу", "FileAccess")]
     public enum FileAccessEnum
     {
-        [EnumValue("Запись")]
+        [EnumValue("Запись", "Write")]
         Write,
-        [EnumValue("Чтение")]
+        [EnumValue("Чтение", "Read")]
         Read,
-        [EnumValue("ЧтениеИЗапись")]
+        [EnumValue("ЧтениеИЗапись", "ReadAndWrite")]
         ReadAndWrite
     }
 
-    [EnumerationType("ПозицияВПотоке", "StreamPosition")]
+    [ContextMethod("StreamPosition", IsDeprecated = true)]
+    [EnumerationType("ПозицияВПотоке", "PositionInStream")]
     public enum StreamPositionEnum
     {
-        [EnumValue("Начало")]
+        [EnumValue("Начало", "Begin")]
         Begin,
-        [EnumValue("Конец")]
+        [EnumValue("Конец", "End")]
         End,
-        [EnumValue("Текущая")]
+        [EnumValue("Текущая", "Current")]
         Current
     }
 

--- a/src/OneScript.StandardLibrary/StringOperations.cs
+++ b/src/OneScript.StandardLibrary/StringOperations.cs
@@ -263,9 +263,9 @@ namespace OneScript.StandardLibrary
     [EnumerationType("НаправлениеПоиска", "SearchDirection")]
     public enum SearchDirection
     {
-        [EnumValue("СНачала")]
+        [EnumValue("СНачала", "FromBegin")]
         FromBegin,
-        [EnumValue("СКонца")]
+        [EnumValue("СКонца", "FromEnd")]
         FromEnd
     }
 

--- a/src/OneScript.StandardLibrary/Text/ConsoleContext.cs
+++ b/src/OneScript.StandardLibrary/Text/ConsoleContext.cs
@@ -210,7 +210,7 @@ namespace OneScript.StandardLibrary.Text
         /// <summary>
         /// Воспроизводит звуковой сигнал.
         /// </summary>
-        [ContextMethod("Сигнал")]
+        [ContextMethod("Сигнал", "Beep")]
         public void Beep()
         {
             Console.Beep();

--- a/src/ScriptEngine.HostedScript/SystemGlobalContext.cs
+++ b/src/ScriptEngine.HostedScript/SystemGlobalContext.cs
@@ -158,7 +158,8 @@ namespace ScriptEngine.HostedScript.Library
         /// Каталог исполняемых файлов OneScript
         /// </summary>
         /// <returns></returns>
-        [ContextMethod("КаталогПрограммы","ProgramDirectory")]
+        [ContextMethod("ProgramDirectory", IsDeprecated = true)]
+        [ContextMethod("КаталогПрограммы","BinDir")]
         public string ProgramDirectory()
         {
             var asm = System.Reflection.Assembly.GetExecutingAssembly();

--- a/src/ScriptEngine.HostedScript/TemplateStorage.cs
+++ b/src/ScriptEngine.HostedScript/TemplateStorage.cs
@@ -86,9 +86,9 @@ namespace ScriptEngine.HostedScript
     [EnumerationType("ТипМакета", "TemplateKind")]
     public enum TemplateKind
     {
-        [EnumValue("Файл")]
+        [EnumValue("Файл", "File")]
         File,
-        [EnumValue("ДвоичныеДанные")]
+        [EnumValue("ДвоичныеДанные", "BinaryData")]
         BinaryData
     }
     


### PR DESCRIPTION
Поправил/дописал английские варианты в ContextMethod-ы, ContextClass-ы, EnumerationType-ы и пр. где ловил ошибки или видел пропущенные переводы. Надеюсь, я правильно понял, как это работает)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added English aliases for all public methods and enum values previously available only in Russian, improving accessibility for English-speaking users.
  - Updated method and enum annotations to support both Russian and English identifiers across binary data operations, console functions, and template types.
  - Deprecated the "ProgramDirectory" alias in favor of "BinDir" for program directory access.

- **Style**
  - Enhanced bilingual support throughout the user interface for method and enum names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->