### PR TITLE
V2 fix #1542: точное позиционирование места ошибки

### DIFF
--- a/src/OneScript.Language/LanguageDef.cs
+++ b/src/OneScript.Language/LanguageDef.cs
@@ -292,7 +292,6 @@ namespace OneScript.Language
                    || token == Token.Modulo
                    || token == Token.And
                    || token == Token.Or
-                   || token == Token.Not
                    || token == Token.LessThan
                    || token == Token.LessOrEqual
                    || token == Token.MoreThan

--- a/src/OneScript.Language/LanguageDef.cs
+++ b/src/OneScript.Language/LanguageDef.cs
@@ -17,6 +17,8 @@ namespace OneScript.Language
         static readonly Dictionary<Token, int> _priority = new Dictionary<Token, int>();
         public const int MAX_OPERATION_PRIORITY = 8;
 
+        private static readonly Dictionary<Token, (string, string)> _keywords = new Dictionary<Token, (string, string)>();
+        
         private static readonly IdentifiersTrie<Token> _stringToToken = new IdentifiersTrie<Token>();
 
         private static readonly IdentifiersTrie<bool> _undefined = new IdentifiersTrie<bool>();
@@ -72,42 +74,42 @@ namespace OneScript.Language
 
             #region Ключевые слова
 
-            AddToken(Token.If, "если", "if");
-            AddToken(Token.Then, "тогда", "then");
-            AddToken(Token.Else, "иначе", "else");
-            AddToken(Token.ElseIf, "иначеесли", "elsif");
-            AddToken(Token.EndIf, "конецесли", "endif");
-            AddToken(Token.VarDef, "перем", "var");
-            AddToken(Token.ByValParam, "знач", "val");
-            AddToken(Token.Procedure, "процедура", "procedure");
-            AddToken(Token.EndProcedure, "конецпроцедуры", "endprocedure");
-            AddToken(Token.Function, "функция", "function");
-            AddToken(Token.EndFunction, "конецфункции", "endfunction");
-            AddToken(Token.For, "для", "for");
-            AddToken(Token.Each, "каждого", "each");
-            AddToken(Token.In, "из", "in");
-            AddToken(Token.To, "по", "to");
-            AddToken(Token.While, "пока", "while");
-            AddToken(Token.Loop, "цикл", "do");
-            AddToken(Token.EndLoop, "конеццикла", "enddo");
-            AddToken(Token.Return, "возврат", "return");
-            AddToken(Token.Continue, "продолжить", "continue");
-            AddToken(Token.Break, "прервать", "break");
-            AddToken(Token.Try, "попытка", "try");
-            AddToken(Token.Exception, "исключение", "except");
-            AddToken(Token.Execute, "выполнить", "execute");
-            AddToken(Token.RaiseException, "вызватьисключение", "raise");
-            AddToken(Token.EndTry, "конецпопытки", "endtry");
-            AddToken(Token.NewObject, "новый", "new");
-            AddToken(Token.Export, "экспорт", "export");
-            AddToken(Token.And, "и", "and");
-            AddToken(Token.Or, "или", "or");
-            AddToken(Token.Not, "не", "not");
-            AddToken(Token.AddHandler, "ДобавитьОбработчик", "AddHandler");
-            AddToken(Token.RemoveHandler, "УдалитьОбработчик", "RemoveHandler");
-            AddToken(Token.Async, "Асинх", "Async");
-            AddToken(Token.Await, "Ждать", "Await");
-            AddToken(Token.Goto, "Перейти", "Goto");
+            AddKeyword(Token.If, "Если", "If");
+            AddKeyword(Token.Then, "Тогда", "Then");
+            AddKeyword(Token.Else, "Иначе", "Else");
+            AddKeyword(Token.ElseIf, "ИначеЕсли", "ElsIf");
+            AddKeyword(Token.EndIf, "КонецЕсли", "EndIf");
+            AddKeyword(Token.VarDef, "Перем", "Var");
+            AddKeyword(Token.ByValParam, "Знач", "Val");
+            AddKeyword(Token.Procedure, "Процедура", "Procedure");
+            AddKeyword(Token.EndProcedure, "КонецПроцедуры", "EndProcedure");
+            AddKeyword(Token.Function, "Функция", "Function");
+            AddKeyword(Token.EndFunction, "КонецФункции", "EndFunction");
+            AddKeyword(Token.For, "Для", "For");
+            AddKeyword(Token.Each, "Каждого", "Each");
+            AddKeyword(Token.In, "Из", "In");
+            AddKeyword(Token.To, "По", "To");
+            AddKeyword(Token.While, "Пока", "While");
+            AddKeyword(Token.Loop, "Цикл", "Do");
+            AddKeyword(Token.EndLoop, "КонецЦикла", "EndDo");
+            AddKeyword(Token.Return, "Возврат", "Return");
+            AddKeyword(Token.Continue, "Продолжить", "Continue");
+            AddKeyword(Token.Break, "Прервать", "Break");
+            AddKeyword(Token.Try, "Попытка", "Try");
+            AddKeyword(Token.Exception, "Исключение", "Except");
+            AddKeyword(Token.Execute, "Выполнить", "Execute");
+            AddKeyword(Token.RaiseException, "ВызватьИсключение", "Raise");
+            AddKeyword(Token.EndTry, "КонецПопытки", "EndTry");
+            AddKeyword(Token.NewObject, "Новый", "New");
+            AddKeyword(Token.Export, "Экспорт", "Export");
+            AddKeyword(Token.And, "И", "And");
+            AddKeyword(Token.Or, "Или", "Or");
+            AddKeyword(Token.Not, "Не", "Not");
+            AddKeyword(Token.AddHandler, "ДобавитьОбработчик", "AddHandler");
+            AddKeyword(Token.RemoveHandler, "УдалитьОбработчик", "RemoveHandler");
+            AddKeyword(Token.Async, "Асинх", "Async");
+            AddKeyword(Token.Await, "Ждать", "Await");
+            AddKeyword(Token.Goto, "Перейти", "Goto");
 
             #endregion
 
@@ -228,6 +230,33 @@ namespace OneScript.Language
             _stringToToken.Add(name, token);
             _stringToToken.Add(alias, token);
         }
+
+        private static void AddKeyword(Token token, string name, string alias)
+        {
+            _keywords.Add(token, (name,alias));
+            _stringToToken.Add(name, token);
+            _stringToToken.Add(alias, token);
+        }
+
+        public static string GetTokenName(Token token)
+        {
+            if (_keywords.TryGetValue(token,out var strings))
+            {
+                return strings.Item1;
+            }
+
+            return Enum.GetName(typeof(Token), token);
+        }
+        public static string GetTokenAlias(Token token)
+        {
+            if (_keywords.TryGetValue(token,out var strings))
+            {
+                return strings.Item2;
+            }
+
+            return Enum.GetName(typeof(Token), token);
+        }
+
 
         public static Token GetToken(string tokText)
         {

--- a/src/OneScript.Language/ScriptException.cs
+++ b/src/OneScript.Language/ScriptException.cs
@@ -98,7 +98,7 @@ namespace OneScript.Language
             {
                 var sb = new StringBuilder(MessageWithoutCodeFragment);
                 sb.AppendLine();
-                sb.AppendLine(Code.Replace('\t', ' ').TrimEnd());
+                sb.AppendLine(Code?.Replace('\t', ' ').TrimEnd());
 
                 if (ColumnNumber != ErrorPositionInfo.OUT_OF_TEXT)
                 {

--- a/src/OneScript.Language/ScriptException.cs
+++ b/src/OneScript.Language/ScriptException.cs
@@ -97,13 +97,20 @@ namespace OneScript.Language
             get
             {
                 var sb = new StringBuilder(MessageWithoutCodeFragment);
-                sb.AppendLine("    ");
-                sb.Append(Code);
+                sb.AppendLine();
+                sb.AppendLine(Code.Replace('\t', ' ').TrimEnd());
+
+                if (ColumnNumber != ErrorPositionInfo.OUT_OF_TEXT)
+                {
+                    if (ColumnNumber > 1)
+                        sb.Append(' ', ColumnNumber - 1);
+                    sb.AppendLine(BilingualString.Localize("^--здесь", "^--here"));
+                }
 
                 return sb.ToString();
             }
         }
-        
+
         public object RuntimeSpecificInfo { get; set; }
         
         public void SetPositionIfEmpty(ErrorPositionInfo newPosition)

--- a/src/OneScript.Language/ScriptException.cs
+++ b/src/OneScript.Language/ScriptException.cs
@@ -98,13 +98,17 @@ namespace OneScript.Language
             {
                 var sb = new StringBuilder(MessageWithoutCodeFragment);
                 sb.AppendLine();
-                sb.AppendLine(Code?.Replace('\t', ' ').TrimEnd());
+                var codeLine = Code?.Replace('\t', ' ').TrimEnd();
 
                 if (ColumnNumber != ErrorPositionInfo.OUT_OF_TEXT)
                 {
-                    if (ColumnNumber > 1)
-                        sb.Append(' ', ColumnNumber - 1);
-                    sb.AppendLine(BilingualString.Localize("^--здесь", "^--here"));
+                    sb.Append(codeLine[..ColumnNumber]);
+                    sb.Append("<<?>>");
+                    sb.AppendLine(codeLine[ColumnNumber..]);
+                }
+                else
+                {
+                    sb.AppendLine(codeLine);
                 }
 
                 return sb.ToString();

--- a/src/OneScript.Language/SyntaxAnalysis/DefaultBslParser.cs
+++ b/src/OneScript.Language/SyntaxAnalysis/DefaultBslParser.cs
@@ -1366,8 +1366,8 @@ namespace OneScript.Language.SyntaxAnalysis
                 }
                 else
                 {
+                    AddError(LocalizedErrors.TokenExpected(stopToken), false);
                     SkipToNextStatement(new []{stopToken});
-                    AddError(LocalizedErrors.ExpressionSyntax(), false);
                     if (_lastExtractedLexem.Token == stopToken)
                     {
                         NextLexem();
@@ -1640,6 +1640,7 @@ namespace OneScript.Language.SyntaxAnalysis
         private void AddError(CodeError err, bool doFastForward = true)
         {
             err.Position = _lexer.GetErrorPosition();
+            err.Position.ColumnNumber -= _lastExtractedLexem.Content.Length;
             ErrorSink.AddError(err);
 
             if (doFastForward)

--- a/src/OneScript.Language/SyntaxAnalysis/DefaultBslParser.cs
+++ b/src/OneScript.Language/SyntaxAnalysis/DefaultBslParser.cs
@@ -1367,11 +1367,6 @@ namespace OneScript.Language.SyntaxAnalysis
                 else
                 {
                     AddError(LocalizedErrors.TokenExpected(stopToken), false);
-                    SkipToNextStatement(new []{stopToken});
-                    if (_lastExtractedLexem.Token == stopToken)
-                    {
-                        NextLexem();
-                    }
                 }
 
                 node = default;
@@ -1640,7 +1635,7 @@ namespace OneScript.Language.SyntaxAnalysis
         private void AddError(CodeError err, bool doFastForward = true)
         {
             err.Position = _lexer.GetErrorPosition();
-            err.Position.ColumnNumber -= _lastExtractedLexem.Content.Length;
+            err.Position.ColumnNumber -= _lastExtractedLexem.Content?.Length ?? 1;
             ErrorSink.AddError(err);
 
             if (doFastForward)

--- a/src/OneScript.Language/SyntaxAnalysis/LocalizedErrors.cs
+++ b/src/OneScript.Language/SyntaxAnalysis/LocalizedErrors.cs
@@ -61,7 +61,7 @@ namespace OneScript.Language.SyntaxAnalysis
             var names = String.Join("/", expected.Select(x => LanguageDef.GetTokenName(x)));
             var aliases = String.Join("/", expected.Select(x => LanguageDef.GetTokenAlias(x)));
            
-            return Create($"Ожидается один из симолов: {names}", $"Expecting  one of symbols: {names}");
+            return Create($"Ожидается один из символов: {names}", $"Expecting  one of symbols: {aliases}");
             
         }
 

--- a/src/OneScript.Language/SyntaxAnalysis/LocalizedErrors.cs
+++ b/src/OneScript.Language/SyntaxAnalysis/LocalizedErrors.cs
@@ -52,9 +52,17 @@ namespace OneScript.Language.SyntaxAnalysis
         
         public static CodeError TokenExpected(params Token[] expected)
         {
-            var names = String.Join("/", expected.Select(x => Enum.GetName(typeof(Token), x)));
+            if (expected.Length == 1)
+            {
+                return Create($"Ожидается символ: {LanguageDef.GetTokenName(expected[0])}",
+                    $"Expecting symbol: {LanguageDef.GetTokenAlias(expected[0])}");
+            }
+
+            var names = String.Join("/", expected.Select(x => LanguageDef.GetTokenName(x)));
+            var aliases = String.Join("/", expected.Select(x => LanguageDef.GetTokenAlias(x)));
+           
+            return Create($"Ожидается один из симолов: {names}", $"Expecting  one of symbols: {names}");
             
-            return Create($"Ожидается символ: {names}", $"Expecting symbol: {names}");
         }
 
         public static CodeError ExportedLocalVar(string varName)

--- a/src/OneScript.Language/SyntaxAnalysis/ModuleAnnotationDirectiveHandler.cs
+++ b/src/OneScript.Language/SyntaxAnalysis/ModuleAnnotationDirectiveHandler.cs
@@ -41,7 +41,9 @@ namespace OneScript.Language.SyntaxAnalysis
 
             if (!_enabled)
             {
-                ErrorSink.AddError(LocalizedErrors.DirectiveNotSupported(lastExtractedLexem.Content));
+                var err = LocalizedErrors.DirectiveNotSupported(lastExtractedLexem.Content);
+                err.Position = lexer.GetErrorPosition();
+                ErrorSink.AddError(err);
                 return true;
             }
 


### PR DESCRIPTION
- изменен тип ошибки при отсутствующем ключевом слове
- убрано перемещение к следующему, т.к. разбор всё равно останавливается
- локализованы ключевые слова в сообщении об одном либо нескольких ожидаемых
- вывод позиции ошибки препроцессора
- указатель на позицию ошибочного символа в исходном коде
- (extra) токен `Not` убран из списка бинарных операторов. Работало, т.к. функция никогда не вызывалась)

По ошибкам препроцессора ещё осталось, что уточнить.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to retrieve localized names and aliases for language keywords.

- **Bug Fixes**
  - Improved error messages to clearly indicate the exact location and nature of syntax errors, including a visual pointer and localized labels.
  - Enhanced error reporting for directives by including precise error positions.

- **Refactor**
  - Refined error messages to use localized token names and aliases, providing more specific feedback when expected tokens are missing.
  - Adjusted error position calculations for more accurate error highlighting in code.
  - Improved parser error handling by directly reporting expected tokens without skipping code.
  - Updated logical classification of operators for clearer syntax interpretation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->