### PR TITLE
fixes #1545 Разрешено иметь комментарии в строке с директивами аннотации модуля

### DIFF
--- a/src/OneScript.Language/ErrorPositionInfo.cs
+++ b/src/OneScript.Language/ErrorPositionInfo.cs
@@ -10,7 +10,7 @@ namespace OneScript.Language
     public class ErrorPositionInfo
     {
         public const int OUT_OF_TEXT = -1;
-
+        
         public ErrorPositionInfo()
         {
             LineNumber = OUT_OF_TEXT;

--- a/src/OneScript.Language/LexicalAnalysis/DefaultLexer.cs
+++ b/src/OneScript.Language/LexicalAnalysis/DefaultLexer.cs
@@ -7,6 +7,9 @@ at http://mozilla.org/MPL/2.0/.
 
 namespace OneScript.Language.LexicalAnalysis
 {
+    /// <summary>
+    /// Лексер, который выдает все, кроме комментариев.
+    /// </summary>
     public class DefaultLexer : FullSourceLexer
     {
         public override Lexem NextLexem()

--- a/src/OneScript.Language/LexicalAnalysis/ExpressionBasedLexer.cs
+++ b/src/OneScript.Language/LexicalAnalysis/ExpressionBasedLexer.cs
@@ -12,9 +12,9 @@ namespace OneScript.Language.LexicalAnalysis
 {
     public class ExpressionBasedLexer : ILexer
     {
-        private readonly Func<char, LexerState> _selector;
+        private readonly Func<SourceCodeIterator, char, LexerState> _selector;
 
-        internal ExpressionBasedLexer(Func<char, LexerState> selector)
+        internal ExpressionBasedLexer(Func<SourceCodeIterator, char, LexerState> selector)
         {
             _selector = selector;
         }
@@ -23,7 +23,7 @@ namespace OneScript.Language.LexicalAnalysis
         {
             if (Iterator.MoveToContent())
             {
-                var state = _selector(Iterator.CurrentSymbol);
+                var state = _selector(Iterator, Iterator.CurrentSymbol);
                 if (state == default)
                 {
                     throw new SyntaxErrorException(Iterator.GetErrorPosition(),

--- a/src/OneScript.Language/LexicalAnalysis/LexerBuilder.cs
+++ b/src/OneScript.Language/LexicalAnalysis/LexerBuilder.cs
@@ -41,7 +41,7 @@ namespace OneScript.Language.LexicalAnalysis
             }
 
 
-            var lambda = Expression.Lambda<Func<char, LexerState>>(expr, charParam);  
+            var lambda = Expression.Lambda<Func<SourceCodeIterator, char, LexerState>>(expr, iteratorParam, charParam);  
             var func = lambda.Compile();
             
             return new ExpressionBasedLexer(func);

--- a/src/OneScript.Language/SyntaxAnalysis/ImportDirectivesHandler.cs
+++ b/src/OneScript.Language/SyntaxAnalysis/ImportDirectivesHandler.cs
@@ -17,8 +17,10 @@ namespace OneScript.Language.SyntaxAnalysis
         public ImportDirectivesHandler(IErrorSink errorSink) : base(errorSink)
         {
             var builder = new LexerBuilder();
-            builder.Detect((cs, i) => !char.IsWhiteSpace(cs))
-                .HandleWith(new NonWhitespaceLexerState());
+            builder
+                .DetectComments()
+                .Detect((cs, i) => !char.IsWhiteSpace(cs))
+                    .HandleWith(new NonWhitespaceLexerState());
 
             _importClauseLexer = builder.Build();
         }
@@ -46,7 +48,7 @@ namespace OneScript.Language.SyntaxAnalysis
             parserContext.AddChild(node);
 
             lex = _importClauseLexer.NextLexemOnSameLine();
-            if (lex.Type != LexemType.EndOfText)
+            if (lex.Type != LexemType.EndOfText && lex.Type != LexemType.Comment)
             {
                 ErrorSink.AddError(LocalizedErrors.UnexpectedOperation());
                 return;

--- a/src/OneScript.Language/SyntaxAnalysis/SingleWordModuleAnnotationHandler.cs
+++ b/src/OneScript.Language/SyntaxAnalysis/SingleWordModuleAnnotationHandler.cs
@@ -24,8 +24,10 @@ namespace OneScript.Language.SyntaxAnalysis
         public SingleWordModuleAnnotationHandler(ISet<string> knownNames, IErrorSink errorSink) : base(errorSink)
         {
             var builder = new LexerBuilder();
-            builder.Detect((cs, i) => !char.IsWhiteSpace(cs))
-                .HandleWith(new WordLexerState());
+            builder
+                .DetectComments()
+                .Detect((cs, i) => !char.IsWhiteSpace(cs))
+                    .HandleWith(new WordLexerState());
 
             _allLineContentLexer = builder.Build();
             _knownNames = knownNames;
@@ -61,7 +63,7 @@ namespace OneScript.Language.SyntaxAnalysis
             // после ничего не должно находиться
             var nextLexem = _allLineContentLexer.NextLexemOnSameLine();
             lastExtractedLexem = lexer.NextLexem(); // сдвиг основного лексера
-            if (nextLexem.Type != LexemType.EndOfText)
+            if (nextLexem.Type != LexemType.EndOfText && nextLexem.Type != LexemType.Comment)
             {
                 var err = LocalizedErrors.ExpressionSyntax();
                 err.Position = new ErrorPositionInfo

--- a/src/OneScript.Language/SyntaxAnalysis/SingleWordModuleAnnotationHandler.cs
+++ b/src/OneScript.Language/SyntaxAnalysis/SingleWordModuleAnnotationHandler.cs
@@ -23,21 +23,25 @@ namespace OneScript.Language.SyntaxAnalysis
 
         public SingleWordModuleAnnotationHandler(ISet<string> knownNames, IErrorSink errorSink) : base(errorSink)
         {
-            var builder = new LexerBuilder();
-            builder
-                .DetectComments()
-                .Detect((cs, i) => !char.IsWhiteSpace(cs))
-                    .HandleWith(new WordLexerState());
+            var builder = SetupLexerBuilder();
 
             _allLineContentLexer = builder.Build();
             _knownNames = knownNames;
         }
-        
-        public SingleWordModuleAnnotationHandler(ISet<BilingualString> knownNames, IErrorSink errorSink) : base(errorSink)
+
+        private static LexerBuilder SetupLexerBuilder()
         {
             var builder = new LexerBuilder();
-            builder.Detect((cs, i) => !char.IsWhiteSpace(cs))
+            builder
+                .DetectComments()
+                .Detect((cs, i) => !char.IsWhiteSpace(cs))
                 .HandleWith(new WordLexerState());
+            return builder;
+        }
+
+        public SingleWordModuleAnnotationHandler(ISet<BilingualString> knownNames, IErrorSink errorSink) : base(errorSink)
+        {
+            var builder = SetupLexerBuilder();
 
             _allLineContentLexer = builder.Build();
 

--- a/src/OneScript.Language/SyntaxErrorException.cs
+++ b/src/OneScript.Language/SyntaxErrorException.cs
@@ -14,7 +14,7 @@ namespace OneScript.Language
 
         }
 
-        internal SyntaxErrorException(CodeError error) : base(error.Position, error.Description)
+        internal SyntaxErrorException(CodeError error) : base(error.Position ?? new ErrorPositionInfo(), error.Description)
         {
             
         }

--- a/src/Tests/DocumenterTests/DocumenterTests.csproj
+++ b/src/Tests/DocumenterTests/DocumenterTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
+    <Import Project="$(MSBuildProjectDirectory)/../../oscommon.targets" />
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>$(TargetFrameworkVersion)</TargetFramework>
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>
         <LangVersion>8</LangVersion>

--- a/src/Tests/OneScript.Language.Tests/ParserTests.cs
+++ b/src/Tests/OneScript.Language.Tests/ParserTests.cs
@@ -958,6 +958,46 @@ namespace OneScript.Language.Tests
             batch.NoMoreChildren();
         }
 
+        [Fact]
+        public void CanHaveCommentAfterUseStatement()
+        {
+            var code = @"
+            #Использовать Библиотека // Подключаем библиотеку
+            #Использовать ""Библиотека с кавычками"" // Подключаем библиотеку с кавычками
+            ";
+            
+            var defaultLex = new DefaultLexer();
+            defaultLex.Iterator = SourceCodeHelper.FromString(code).CreateIterator();
+            
+            var lexer = new PreprocessingLexer(defaultLex);
+            
+            lexer.Handlers = new PreprocessorHandlers(
+                new[] {new ImportDirectivesHandler(new ThrowingErrorSink())});
+            
+            var parser = new DefaultBslParser(
+                lexer,
+                new ListErrorSink(),
+                lexer.Handlers);
+
+            var moduleNode = parser.ParseStatefulModule();
+            moduleNode.Should().NotBeNull();
+            parser.Errors.Should().BeEmpty("the valid code is passed");
+            var firstChild = new SyntaxTreeValidator(new TestAstNode(moduleNode.Children.First()));
+            
+            var batch = new SyntaxTreeValidator(new TestAstNode(firstChild.CurrentNode.RealNode.Parent));
+            
+            var node = batch.NextChild();
+            node.Is(NodeKind.Import)
+                .Equal("Использовать");
+            node.NextChild().Is(NodeKind.AnnotationParameter)
+                .Equal("Библиотека");
+            
+            node = batch.NextChild();
+            node.Is(NodeKind.Import)
+                .Equal("Использовать");
+            node.NextChild().Is(NodeKind.AnnotationParameter)
+                .Equal("\"Библиотека с кавычками\"");
+        }
 
         [Fact]
         public void Check_No_Semicolon_In_If()

--- a/src/Tests/OneScript.Language.Tests/TestAstNode.cs
+++ b/src/Tests/OneScript.Language.Tests/TestAstNode.cs
@@ -31,6 +31,7 @@ namespace OneScript.Language.Tests
                     BinaryOperationNode binary => binary.Operation.ToString(),
                     UnaryOperationNode unary => unary.Operation.ToString(),
                     PreprocessorDirectiveNode preproc => preproc.DirectiveName,
+                    AnnotationParameterNode annParam => annParam.Value.Content,
                     _ => nonTerm.ToString()
                 };
             }

--- a/src/Tests/OneScript.StandardLibrary.Tests/FileBackingStreamTest.cs
+++ b/src/Tests/OneScript.StandardLibrary.Tests/FileBackingStreamTest.cs
@@ -5,211 +5,216 @@ was not distributed with this file, You can obtain one
 at http://mozilla.org/MPL/2.0/.
 ----------------------------------------------------------*/
 
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Xunit;
 using FluentAssertions;
 using OneScript.StandardLibrary.Binary;
 
-namespace OneScript.StandardLibrary.Tests;
-
-public class FileBackingStreamTest
+namespace OneScript.StandardLibrary.Tests
 {
-    [Fact]
-    public void CanDoBasicReadWithMemory()
+    public class FileBackingStreamTest
     {
-        using var stream = new FileBackingStream(10);
-        stream.Write(new byte[]{1,2,3,4,5});
-
-        stream.Position = 0;
-        stream.Position.Should().Be(0);
-        stream.HasBackingFile.Should().BeFalse();
-        stream.Length.Should().Be(5);
-
-        var dest = new byte[5];
-        var size = stream.Read(dest, 0, 5);
-        size.Should().Be(5);
-        dest.Should().Equal(1, 2, 3, 4, 5);
-    }
-    
-    [Fact]
-    public void CanDoBasicReadWithFile()
-    {
-        using var stream = new FileBackingStream(10);
-        stream.SwitchToFile();
-        stream.Write(new byte[]{1,2,3,4,5});
-
-        stream.Position = 0;
-        stream.Position.Should().Be(0);
-        stream.HasBackingFile.Should().BeTrue();
-        stream.Length.Should().Be(5);
-
-        var dest = new byte[5];
-        var size = stream.Read(dest, 0, 5);
-        size.Should().Be(5);
-        dest.Should().Equal(1, 2, 3, 4, 5);
-    }
-
-    [Fact]
-    public void GrowsOnWriteToEnd()
-    {
-        using var stream = new FileBackingStream(5);
-        stream.Write(new byte[]{1,2,3,4,5});
-        stream.HasBackingFile.Should().BeFalse();
-        stream.Position.Should().Be(5);
-        
-        stream.Write(new byte[]{1,2,3,4,5});
-        stream.HasBackingFile.Should().BeTrue();
-        stream.Position.Should().Be(10);
-        stream.Length.Should().Be(10);
-        
-        EnsureContent(stream, new byte[]{1,2,3,4,5,1,2,3,4,5});
-    }
-    
-    [Fact]
-    public void GrowsOnWriteToMiddle()
-    {
-        using var stream = new FileBackingStream(5);
-        stream.Write(new byte[]{1,2,3,4,5});
-        stream.Position = 2;
-        stream.HasBackingFile.Should().BeFalse();
-        
-        stream.Write(new byte[]{6,6,6,6,6});
-        stream.HasBackingFile.Should().BeTrue();
-        stream.Position.Should().Be(7);
-        stream.Length.Should().Be(7);
-        
-        EnsureContent(stream, new byte[]{1,2,6,6,6,6,6});
-    }
-    
-    [Fact]
-    public void GrowsOnWriteToStart()
-    {
-        using var stream = new FileBackingStream(5);
-        stream.Write(new byte[]{1,2,3,4,5});
-        stream.Position = 0;
-        stream.HasBackingFile.Should().BeFalse();
-        
-        stream.Write(new byte[]{7,6,5,4,3,2,1});
-        stream.HasBackingFile.Should().BeTrue();
-        stream.Position.Should().Be(7);
-        stream.Length.Should().Be(7);
-        
-        EnsureContent(stream, new byte[]{7,6,5,4,3,2,1});
-    }
-    
-    [Fact]
-    public void DoesNotGrowOnWriteInsideLimit()
-    {
-        using var stream = new FileBackingStream(5);
-        stream.Write(new byte[]{1,2,3,4,5});
-        stream.Position = 2;
-        stream.HasBackingFile.Should().BeFalse();
-        
-        stream.Write(new byte[]{0,0,0});
-        stream.HasBackingFile.Should().BeFalse();
-        stream.Position.Should().Be(5);
-        stream.Length.Should().Be(5);
-        
-        EnsureContent(stream, new byte[]{1,2,0,0,0});
-    }
-    
-    [Fact]
-    public void CanCropIntoMemoryAgain()
-    {
-        using var stream = new FileBackingStream(5);
-        stream.Write(new byte[]{1,2,3,4,5,6,7,8,9,10});
-        stream.HasBackingFile.Should().BeTrue();
-        stream.Length.Should().Be(10);
-        stream.SetLength(5);
-        stream.HasBackingFile.Should().BeFalse();
-        
-        EnsureContent(stream, new byte[]{1,2,3,4,5});
-    }
-    
-    [Fact]
-    public void SettingLengthBeyondLimitSwitchesToFile()
-    {
-        using var stream = new FileBackingStream(5);
-        stream.HasBackingFile.Should().BeFalse();
-        stream.SetLength(15);
-        stream.HasBackingFile.Should().BeTrue();
-    }
-    
-    [Fact]
-    public void ThrowsWhenCantSwitchIntoMemory()
-    {
-        using var stream = new FileBackingStream(5);
-        stream.Write(new byte[]{1,2,3,4,5,6,7,8,9,10});
-        stream.HasBackingFile.Should().BeTrue();
-        
-        Assert.Throws<InvalidOperationException>(() => stream.SwitchToMemory());
-    }
-
-    [Fact]
-    public void SetPositionBeyondLength()
-    {
-        using var stream = new FileBackingStream(5);
-        stream.Position = 10;
-        
-        stream.Length.Should().Be(0);
-        stream.HasBackingFile.Should().BeFalse();
-        
-        stream.Write(new byte[]{1,2,3});
-        stream.Position.Should().Be(13);
-        stream.Length.Should().Be(13);
-        stream.HasBackingFile.Should().BeTrue();
-    }
-
-    [Fact]
-    public void TempFileGetsDeletedOnClose()
-    {
-        using var stream = new FileBackingStream(5);
-        stream.Write(new byte[]{1,2,3,4,5,6,7,8,9,10});
-        stream.HasBackingFile.Should().BeTrue();
-        var tempFile = stream.FileName;
-        
-        stream.SetLength(4);
-        stream.HasBackingFile.Should().BeFalse();
-        File.Exists(tempFile).Should().BeFalse();
-    }
-
-    private void EnsureContent(Stream stream, IEnumerable<byte> expected)
-    {
-        stream.Position = 0;
-        var actual = new byte[stream.Length];
-        stream.Read(actual).Should().Be((int)stream.Length);
-
-        actual.Should().Equal(expected);
-    }
-    
-    [Fact(Skip = "Platform test")]
-    public void SetPositionBeyondMemoryStream()
-    {
-        using var ms = new MemoryStream();
-        ms.Position = 10;
-        
-        ms.Length.Should().Be(0);
-        ms.Write(new byte[]{1,2,3});
-        ms.Position.Should().Be(13);
-        ms.Length.Should().Be(13);
-    }
-    
-    [Fact(Skip = "Platform test")]
-    public void SetPositionBeyondFileStream()
-    {
-        var path = Path.GetTempFileName();
-        var fs = new FileStream(path, FileMode.Create);
-        try
+        [Fact]
+        public void CanDoBasicReadWithMemory()
         {
-            fs.Position = 10;
+            using var stream = new FileBackingStream(10);
+            stream.Write(new byte[] { 1, 2, 3, 4, 5 });
 
-            fs.Length.Should().Be(0);
-            fs.Write(new byte[] { 1, 2, 3 });
-            fs.Position.Should().Be(13);
-            fs.Length.Should().Be(13);
+            stream.Position = 0;
+            stream.Position.Should().Be(0);
+            stream.HasBackingFile.Should().BeFalse();
+            stream.Length.Should().Be(5);
+
+            var dest = new byte[5];
+            var size = stream.Read(dest, 0, 5);
+            size.Should().Be(5);
+            dest.Should().Equal(1, 2, 3, 4, 5);
         }
-        finally
+
+        [Fact]
+        public void CanDoBasicReadWithFile()
         {
-            fs.Close();
-            File.Delete(path);
+            using var stream = new FileBackingStream(10);
+            stream.SwitchToFile();
+            stream.Write(new byte[] { 1, 2, 3, 4, 5 });
+
+            stream.Position = 0;
+            stream.Position.Should().Be(0);
+            stream.HasBackingFile.Should().BeTrue();
+            stream.Length.Should().Be(5);
+
+            var dest = new byte[5];
+            var size = stream.Read(dest, 0, 5);
+            size.Should().Be(5);
+            dest.Should().Equal(1, 2, 3, 4, 5);
+        }
+
+        [Fact]
+        public void GrowsOnWriteToEnd()
+        {
+            using var stream = new FileBackingStream(5);
+            stream.Write(new byte[] { 1, 2, 3, 4, 5 });
+            stream.HasBackingFile.Should().BeFalse();
+            stream.Position.Should().Be(5);
+
+            stream.Write(new byte[] { 1, 2, 3, 4, 5 });
+            stream.HasBackingFile.Should().BeTrue();
+            stream.Position.Should().Be(10);
+            stream.Length.Should().Be(10);
+
+            EnsureContent(stream, new byte[] { 1, 2, 3, 4, 5, 1, 2, 3, 4, 5 });
+        }
+
+        [Fact]
+        public void GrowsOnWriteToMiddle()
+        {
+            using var stream = new FileBackingStream(5);
+            stream.Write(new byte[] { 1, 2, 3, 4, 5 });
+            stream.Position = 2;
+            stream.HasBackingFile.Should().BeFalse();
+
+            stream.Write(new byte[] { 6, 6, 6, 6, 6 });
+            stream.HasBackingFile.Should().BeTrue();
+            stream.Position.Should().Be(7);
+            stream.Length.Should().Be(7);
+
+            EnsureContent(stream, new byte[] { 1, 2, 6, 6, 6, 6, 6 });
+        }
+
+        [Fact]
+        public void GrowsOnWriteToStart()
+        {
+            using var stream = new FileBackingStream(5);
+            stream.Write(new byte[] { 1, 2, 3, 4, 5 });
+            stream.Position = 0;
+            stream.HasBackingFile.Should().BeFalse();
+
+            stream.Write(new byte[] { 7, 6, 5, 4, 3, 2, 1 });
+            stream.HasBackingFile.Should().BeTrue();
+            stream.Position.Should().Be(7);
+            stream.Length.Should().Be(7);
+
+            EnsureContent(stream, new byte[] { 7, 6, 5, 4, 3, 2, 1 });
+        }
+
+        [Fact]
+        public void DoesNotGrowOnWriteInsideLimit()
+        {
+            using var stream = new FileBackingStream(5);
+            stream.Write(new byte[] { 1, 2, 3, 4, 5 });
+            stream.Position = 2;
+            stream.HasBackingFile.Should().BeFalse();
+
+            stream.Write(new byte[] { 0, 0, 0 });
+            stream.HasBackingFile.Should().BeFalse();
+            stream.Position.Should().Be(5);
+            stream.Length.Should().Be(5);
+
+            EnsureContent(stream, new byte[] { 1, 2, 0, 0, 0 });
+        }
+
+        [Fact]
+        public void CanCropIntoMemoryAgain()
+        {
+            using var stream = new FileBackingStream(5);
+            stream.Write(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 });
+            stream.HasBackingFile.Should().BeTrue();
+            stream.Length.Should().Be(10);
+            stream.SetLength(5);
+            stream.HasBackingFile.Should().BeFalse();
+
+            EnsureContent(stream, new byte[] { 1, 2, 3, 4, 5 });
+        }
+
+        [Fact]
+        public void SettingLengthBeyondLimitSwitchesToFile()
+        {
+            using var stream = new FileBackingStream(5);
+            stream.HasBackingFile.Should().BeFalse();
+            stream.SetLength(15);
+            stream.HasBackingFile.Should().BeTrue();
+        }
+
+        [Fact]
+        public void ThrowsWhenCantSwitchIntoMemory()
+        {
+            using var stream = new FileBackingStream(5);
+            stream.Write(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 });
+            stream.HasBackingFile.Should().BeTrue();
+
+            Assert.Throws<InvalidOperationException>(() => stream.SwitchToMemory());
+        }
+
+        [Fact]
+        public void SetPositionBeyondLength()
+        {
+            using var stream = new FileBackingStream(5);
+            stream.Position = 10;
+
+            stream.Length.Should().Be(0);
+            stream.HasBackingFile.Should().BeFalse();
+
+            stream.Write(new byte[] { 1, 2, 3 });
+            stream.Position.Should().Be(13);
+            stream.Length.Should().Be(13);
+            stream.HasBackingFile.Should().BeTrue();
+        }
+
+        [Fact]
+        public void TempFileGetsDeletedOnClose()
+        {
+            using var stream = new FileBackingStream(5);
+            stream.Write(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 });
+            stream.HasBackingFile.Should().BeTrue();
+            var tempFile = stream.FileName;
+
+            stream.SetLength(4);
+            stream.HasBackingFile.Should().BeFalse();
+            File.Exists(tempFile).Should().BeFalse();
+        }
+
+        private void EnsureContent(Stream stream, IEnumerable<byte> expected)
+        {
+            stream.Position = 0;
+            var actual = new byte[stream.Length];
+            stream.Read(actual).Should().Be((int)stream.Length);
+
+            actual.Should().Equal(expected);
+        }
+
+        [Fact(Skip = "Platform test")]
+        public void SetPositionBeyondMemoryStream()
+        {
+            using var ms = new MemoryStream();
+            ms.Position = 10;
+
+            ms.Length.Should().Be(0);
+            ms.Write(new byte[] { 1, 2, 3 });
+            ms.Position.Should().Be(13);
+            ms.Length.Should().Be(13);
+        }
+
+        [Fact(Skip = "Platform test")]
+        public void SetPositionBeyondFileStream()
+        {
+            var path = Path.GetTempFileName();
+            var fs = new FileStream(path, FileMode.Create);
+            try
+            {
+                fs.Position = 10;
+
+                fs.Length.Should().Be(0);
+                fs.Write(new byte[] { 1, 2, 3 });
+                fs.Position.Should().Be(13);
+                fs.Length.Should().Be(13);
+            }
+            finally
+            {
+                fs.Close();
+                File.Delete(path);
+            }
         }
     }
 }

--- a/src/Tests/OneScript.StandardLibrary.Tests/OneScript.StandardLibrary.Tests.csproj
+++ b/src/Tests/OneScript.StandardLibrary.Tests/OneScript.StandardLibrary.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
+    <Import Project="$(MSBuildProjectDirectory)/../../oscommon.targets" />
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>$(TargetFrameworkVersion)</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 

--- a/src/Tests/OneScript.StandardLibrary.Tests/Usings.cs
+++ b/src/Tests/OneScript.StandardLibrary.Tests/Usings.cs
@@ -1,8 +1,0 @@
-/*----------------------------------------------------------
-This Source Code Form is subject to the terms of the
-Mozilla Public License, v.2.0. If a copy of the MPL
-was not distributed with this file, You can obtain one
-at http://mozilla.org/MPL/2.0/.
-----------------------------------------------------------*/
-
-global using Xunit;

--- a/src/oscommon.targets
+++ b/src/oscommon.targets
@@ -7,7 +7,7 @@
         <Configuration Condition="'$(Configuration)' == ''">Release</Configuration>
         <Platform Condition="'$(Platform)' == ''">x86</Platform>
         <LangVersion>8.0</LangVersion>
-        <TargetFrameworkVersion>net8.0</TargetFrameworkVersion>
+        <TargetFrameworkVersion>net6.0</TargetFrameworkVersion>
         <NoWarn>$(NoWarn);CS1591</NoWarn>
         <IncludeSourceRevisionInInformationalVersion>False</IncludeSourceRevisionInInformationalVersion>
         <ImplicitUsings>disable</ImplicitUsings>

--- a/src/oscommon.targets
+++ b/src/oscommon.targets
@@ -7,9 +7,10 @@
         <Configuration Condition="'$(Configuration)' == ''">Release</Configuration>
         <Platform Condition="'$(Platform)' == ''">x86</Platform>
         <LangVersion>8.0</LangVersion>
-        <TargetFrameworkVersion>net6.0</TargetFrameworkVersion>
+        <TargetFrameworkVersion>net8.0</TargetFrameworkVersion>
         <NoWarn>$(NoWarn);CS1591</NoWarn>
         <IncludeSourceRevisionInInformationalVersion>False</IncludeSourceRevisionInInformationalVersion>
+        <ImplicitUsings>disable</ImplicitUsings>
     </PropertyGroup>
 	
     <PropertyGroup>


### PR DESCRIPTION
closes #1545 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Parser now supports comments after import (`#Использовать`) directives without causing errors.
  - Lexer enhanced to recognize comments explicitly in import and annotation handlers.

- **Bug Fixes**
  - Improved error handling for syntax errors when position information is missing.

- **Documentation**
  - Added XML documentation for the lexer class.

- **Style**
  - Reformatted test files for consistency and clarity.

- **Tests**
  - Added tests to verify correct parsing of comments after import directives.
  - Introduced helper methods and platform-specific stream tests.

- **Chores**
  - Updated project files to support configurable target frameworks and unified build targets.
  - Disabled implicit usings in build configuration.
  - Removed unused global using directives.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->