### PR TITLE
Перевод на net8

### DIFF
--- a/Build.csproj
+++ b/Build.csproj
@@ -14,6 +14,8 @@
         <Configuration>Release</Configuration>
         <Solution>$(MSBuildProjectDirectory)/src/1Script.sln</Solution>
         
+        <ActiveFramework>net8.0</ActiveFramework>
+        
     </PropertyGroup>
     
     <ItemGroup>
@@ -30,11 +32,11 @@
     <ItemGroup>
         <PublishProjects Include="oscript">
             <ProjectFile>oscript.csproj</ProjectFile>
-            <Framework>net8.0</Framework>
+            <Framework>$(ActiveFramework)</Framework>
         </PublishProjects>
         <PublishProjects Include="TestApp">
             <ProjectFile>TestApp.csproj</ProjectFile>
-            <Framework>net8.0-windows</Framework>
+            <Framework>$(ActiveFramework)-windows</Framework>
         </PublishProjects>
     </ItemGroup>
     
@@ -106,7 +108,7 @@
         </ItemGroup>
         
         <Exec Command="dotnet publish &quot;src/oscript/oscript.csproj&quot; -r %(RuntimeID.Identity) --self-contained -c $(Configuration) -o &quot;$(ArtifactsRoot)/%(RuntimeID.Identity)/bin&quot;" UseUtf8Encoding="Always"/>
-        <Exec Command="dotnet publish &quot;src/TestApp/TestApp.csproj&quot; -f net6.0-windows -c $(Configuration) -p:Platform=%(PlatformItem.MSBuildName) -p:UseAppHost=true -o &quot;$(ArtifactsRoot)/win-%(PlatformItem.Identity)/bin&quot;" UseUtf8Encoding="Always"/>
+        <Exec Command="dotnet publish &quot;src/TestApp/TestApp.csproj&quot; -f $(ActiveFramework)-windows -c $(Configuration) -p:Platform=%(PlatformItem.MSBuildName) -p:UseAppHost=true -o &quot;$(ArtifactsRoot)/win-%(PlatformItem.Identity)/bin&quot;" UseUtf8Encoding="Always"/>
 
         <PropertyGroup>
             <CppBinPrefix>$(MSBuildProjectDirectory)/src/ScriptEngine.NativeApi/bin/$(Configuration)</CppBinPrefix>

--- a/Build.csproj
+++ b/Build.csproj
@@ -30,11 +30,11 @@
     <ItemGroup>
         <PublishProjects Include="oscript">
             <ProjectFile>oscript.csproj</ProjectFile>
-            <Framework>net6.0</Framework>
+            <Framework>net8.0</Framework>
         </PublishProjects>
         <PublishProjects Include="TestApp">
             <ProjectFile>TestApp.csproj</ProjectFile>
-            <Framework>net6.0-windows</Framework>
+            <Framework>net8.0-windows</Framework>
         </PublishProjects>
     </ItemGroup>
     

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ pipeline {
 
     environment {
         VersionPrefix = '2.0.0'
-        VersionSuffix = 'rc.8'+"+${BUILD_NUMBER}"
+        VersionSuffix = 'rc.9'+"+${BUILD_NUMBER}"
         outputEnc = '65001'
     }
 

--- a/src/OneScript.DebugProtocol/TcpServer/BinaryChannel.cs
+++ b/src/OneScript.DebugProtocol/TcpServer/BinaryChannel.cs
@@ -8,9 +8,12 @@ at http://mozilla.org/MPL/2.0/.
 using System;
 using System.Net.Sockets;
 using System.Runtime.Serialization;
+#if NET48
 using System.Runtime.Serialization.Formatters.Binary;
+#endif
 using OneScript.DebugProtocol.Abstractions;
 
+// ReSharper disable once CheckNamespace
 namespace OneScript.DebugProtocol
 {
     /// <summary>

--- a/src/TestApp/TestApp.csproj
+++ b/src/TestApp/TestApp.csproj
@@ -3,7 +3,7 @@
   <Import Project="$(MSBuildProjectDirectory)/../oscommon.targets" />
   
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <!--LanguageTargets>$(MSBuildExtensionsPath)\$(VisualStudioVersion)\Bin\Microsoft.CSharp.targets</LanguageTargets-->
     <ApplicationIcon>logo.ico</ApplicationIcon>
     <OutputType>WinExe</OutputType>

--- a/src/oscommon.targets
+++ b/src/oscommon.targets
@@ -7,7 +7,7 @@
         <Configuration Condition="'$(Configuration)' == ''">Release</Configuration>
         <Platform Condition="'$(Platform)' == ''">x86</Platform>
         <LangVersion>8.0</LangVersion>
-        <TargetFrameworkVersion>net6.0</TargetFrameworkVersion>
+        <TargetFrameworkVersion>net8.0</TargetFrameworkVersion>
         <NoWarn>$(NoWarn);CS1591</NoWarn>
         <IncludeSourceRevisionInInformationalVersion>False</IncludeSourceRevisionInInformationalVersion>
         <ImplicitUsings>disable</ImplicitUsings>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build scripts and project configurations to use .NET 8.0 instead of .NET 6.0.
  * Increased the release candidate version suffix in the build pipeline from rc.8 to rc.9.
  * Improved framework version management in build scripts for consistency.

* **Bug Fixes**
  * Restricted binary serialization functionality to .NET Framework 4.8 builds only, preventing its use on unsupported frameworks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->