### PR TITLE
v1 fix #1588: передача пропущенных параметров в COM-объекты

### DIFF
--- a/src/ScriptEngine/Machine/Contexts/COMWrapperContext.cs
+++ b/src/ScriptEngine/Machine/Contexts/COMWrapperContext.cs
@@ -146,7 +146,7 @@ namespace ScriptEngine.Machine.Contexts
             }
             else
             {
-                retValue = ContextValuesMarshaller.ConvertToCLRObject(val) ?? Missing.Value;
+                retValue = ContextValuesMarshaller.ConvertToCLRObject(val);
             }
 
             return retValue;

--- a/src/ScriptEngine/Machine/Contexts/COMWrapperContext.cs
+++ b/src/ScriptEngine/Machine/Contexts/COMWrapperContext.cs
@@ -115,8 +115,14 @@ namespace ScriptEngine.Machine.Contexts
                 var flags = new ParameterModifier(arguments.Length);
                 for (int i = 0; i < arguments.Length; i++)
                 {
-                    values[i] = MarshalIValue(arguments[i]);
-                    flags[i] = arguments[i] is IVariable;
+                    if (arguments[i] is IVariable v)
+                    {
+                        values[i] = new System.Runtime.InteropServices.VariantWrapper(MarshalIValue(v.Value));
+                        flags[i] = true;
+                    }
+                    else
+                        values[i] = MarshalIValue(arguments[i]);
+                    
                 }
 
                 flagsArray[0] = flags;
@@ -200,6 +206,7 @@ namespace ScriptEngine.Machine.Contexts
                 return ValueFactory.Create();
 
             var type = objParam.GetType();
+            Console.WriteLine($"objt={type.FullName} isI:{objParam is IValue} A:{type.IsArray} asg:{typeof(IValue).IsAssignableFrom(type)} nP:{!type.IsPrimitive} ");
             if (typeof(IValue).IsAssignableFrom(type))
             {
                 return (IValue)objParam;

--- a/src/ScriptEngine/Machine/Contexts/ContextValuesMarshaller.cs
+++ b/src/ScriptEngine/Machine/Contexts/ContextValuesMarshaller.cs
@@ -251,19 +251,13 @@ namespace ScriptEngine.Machine.Contexts
                 case DataType.Number: return val.AsNumber();
                 case DataType.String: return val.AsString();
                 case DataType.Undefined: return null;
+                case DataType.NotAValidValue: return Missing.Value;
             }
 
-            object result;
-
-            if (val.DataType == DataType.Object)
-                result = val.AsObject();
-
 			if (val.GetRawValue() is IObjectWrapper wrapped)
-				result = wrapped.UnderlyingObject;
-			else
-				throw ValueMarshallingException.NoConversionToCLR(val.GetType());
-
-            return result;
+				return wrapped.UnderlyingObject;
+			
+			throw ValueMarshallingException.NoConversionToCLR(val.GetType());
         }
 
         public static T CastToCLRObject<T>(IValue val)

--- a/src/ScriptEngine/Machine/Contexts/ContextValuesMarshaller.cs
+++ b/src/ScriptEngine/Machine/Contexts/ContextValuesMarshaller.cs
@@ -254,9 +254,12 @@ namespace ScriptEngine.Machine.Contexts
                 case DataType.NotAValidValue: return Missing.Value;
             }
 
-			if (val.GetRawValue() is IObjectWrapper wrapped)
-				return wrapped.UnderlyingObject;
-			
+            if (val.GetRawValue() is IObjectWrapper wrapped)
+                return wrapped.UnderlyingObject;
+
+            if (val.DataType == DataType.Object)
+                return val.AsObject();
+ 			
 			throw ValueMarshallingException.NoConversionToCLR(val.GetType());
         }
 

--- a/src/ScriptEngine/Machine/MachineInstance.cs
+++ b/src/ScriptEngine/Machine/MachineInstance.cs
@@ -1020,7 +1020,7 @@ namespace ScriptEngine.Machine
             IValue[] realArgs;
             if (instance.DynamicMethodSignatures)
             {
-                realArgs = PrepareDynamicArgs(argValues);
+                realArgs = PrepareDynamicArgs(instance, argValues);
             }
             else
             {
@@ -1053,8 +1053,11 @@ namespace ScriptEngine.Machine
             NextInstruction();
         }
 
-        private static IValue[] PrepareDynamicArgs(IValue[] factArgs)
+        private static IValue[] PrepareDynamicArgs(IRuntimeContextInstance context, IValue[] factArgs)
         {
+            if (context is COMWrapperContext)
+                return factArgs;
+
             var realArgs = new IValue[factArgs.Length];
             for (int i = 0; i < factArgs.Length; i++)
             {
@@ -1161,7 +1164,7 @@ namespace ScriptEngine.Machine
     
             if (context.DynamicMethodSignatures)
             {
-                argValues = PrepareDynamicArgs(factArgs);
+                argValues = PrepareDynamicArgs(context, factArgs);
             }
             else
             {


### PR DESCRIPTION
Остается вопрос, какие еще динамические объекты отличают передачу `Неопределено` от пропущенного параметра. Возможно, потребуется модификация PrepareDynamicArgs() 