### PR TITLE
V2: оптимизация ТаблицыЗначений и Рефлектора

### DIFF
--- a/src/OneScript.StandardLibrary/Collections/Indexes/CollectionIndex.cs
+++ b/src/OneScript.StandardLibrary/Collections/Indexes/CollectionIndex.cs
@@ -26,17 +26,17 @@ namespace OneScript.StandardLibrary.Collections.Indexes
         
         public CollectionIndex(IIndexCollectionSource source, IEnumerable<IValue> fields)
         {
-            _source = source;
-            foreach (var value in _source)
-            {
-                ElementAdded(value);
-            }
-
             foreach (var field in fields)
             {
                 if (field is ValueTable.ValueTableColumn column) 
                     column.IsIndexable = true;
                 _fields.Add(field);
+            }
+        
+            _source = source;
+            foreach (var value in _source)
+            {
+                ElementAdded(value);
             }
         }
 

--- a/src/OneScript.StandardLibrary/Collections/Indexes/CollectionIndex.cs
+++ b/src/OneScript.StandardLibrary/Collections/Indexes/CollectionIndex.cs
@@ -18,21 +18,31 @@ namespace OneScript.StandardLibrary.Collections.Indexes
     [ContextClass("ИндексКоллекции", "CollectionIndex")]
     public class CollectionIndex : AutoCollectionContext<CollectionIndex, IValue>
     {
-        private readonly List<IValue> _fields = new List<IValue>();
+        readonly List<IValue> _fields = new List<IValue>();
         private readonly IIndexCollectionSource _source;
 
-        private readonly IDictionary<CollectionIndexKey, HashSet<IValue>> _data =
+        private readonly Dictionary<CollectionIndexKey, HashSet<IValue>> _data =
             new Dictionary<CollectionIndexKey, HashSet<IValue>>();
         
         public CollectionIndex(IIndexCollectionSource source, IEnumerable<IValue> fields)
         {
             _source = source;
-            _fields.AddRange(fields);
+            foreach (var value in _source)
+            {
+                ElementAdded(value);
+            }
+
+            foreach (var field in fields)
+            {
+                if (field is ValueTable.ValueTableColumn column) 
+                    column.IsIndexable = true;
+                _fields.Add(field);
+            }
         }
 
         internal bool CanBeUsedFor(IEnumerable<IValue> searchFields)
         {
-            return _fields.Any() && _fields.ToHashSet().IsSubsetOf(searchFields.ToHashSet());
+            return _fields.Count>0 && _fields.ToHashSet().IsSubsetOf(searchFields);
         }
 
         private CollectionIndexKey IndexKey(PropertyNameIndexAccessor source)
@@ -82,10 +92,7 @@ namespace OneScript.StandardLibrary.Collections.Indexes
             }
         }
 
-        internal void Clear()
-        {
-            _data.Clear();
-        }
+        internal void Clear() => _data.Clear();
 
         internal void Rebuild()
         {

--- a/src/OneScript.StandardLibrary/Collections/Indexes/CollectionIndex.cs
+++ b/src/OneScript.StandardLibrary/Collections/Indexes/CollectionIndex.cs
@@ -81,7 +81,7 @@ namespace OneScript.StandardLibrary.Collections.Indexes
             foreach (var field in _fields)
             {
                 if (field is ValueTable.ValueTableColumn column)
-                    column.AddToIndex();
+                    column.DeleteFromIndex();
             }
         }
 

--- a/src/OneScript.StandardLibrary/Collections/Indexes/CollectionIndex.cs
+++ b/src/OneScript.StandardLibrary/Collections/Indexes/CollectionIndex.cs
@@ -42,7 +42,7 @@ namespace OneScript.StandardLibrary.Collections.Indexes
 
         internal bool CanBeUsedFor(IEnumerable<IValue> searchFields)
         {
-            return _fields.Count>0 && _fields.ToHashSet().IsSubsetOf(searchFields);
+            return _fields.Count > 0 && _fields.All(f => searchFields.Contains(f));
         }
 
         private CollectionIndexKey IndexKey(PropertyNameIndexAccessor source)

--- a/src/OneScript.StandardLibrary/Collections/Indexes/CollectionIndex.cs
+++ b/src/OneScript.StandardLibrary/Collections/Indexes/CollectionIndex.cs
@@ -18,7 +18,7 @@ namespace OneScript.StandardLibrary.Collections.Indexes
     [ContextClass("ИндексКоллекции", "CollectionIndex")]
     public class CollectionIndex : AutoCollectionContext<CollectionIndex, IValue>
     {
-        readonly List<IValue> _fields = new List<IValue>();
+        private readonly List<IValue> _fields = new List<IValue>();
         private readonly IIndexCollectionSource _source;
 
         private readonly Dictionary<CollectionIndexKey, HashSet<IValue>> _data =
@@ -29,7 +29,7 @@ namespace OneScript.StandardLibrary.Collections.Indexes
             foreach (var field in fields)
             {
                 if (field is ValueTable.ValueTableColumn column) 
-                    column.IsIndexable = true;
+                    column.AddToIndex();
                 _fields.Add(field);
             }
         
@@ -65,8 +65,23 @@ namespace OneScript.StandardLibrary.Collections.Indexes
         {
             if (_fields.Contains(field))
             {
-                while (_fields.Contains(field)) _fields.Remove(field);
+                while (_fields.Contains(field))
+                {
+                    if (field is ValueTable.ValueTableColumn column)
+                        column.DeleteFromIndex();
+
+                    _fields.Remove(field);
+                }
                 Rebuild();
+            }
+        }
+
+        internal void ExcludeFields()
+        {
+            foreach (var field in _fields)
+            {
+                if (field is ValueTable.ValueTableColumn column)
+                    column.AddToIndex();
             }
         }
 

--- a/src/OneScript.StandardLibrary/Collections/ValueTable/CollectionIndexes.cs
+++ b/src/OneScript.StandardLibrary/Collections/ValueTable/CollectionIndexes.cs
@@ -32,7 +32,6 @@ namespace OneScript.StandardLibrary.Collections.ValueTable
         public CollectionIndex Add(string columns)
         {
             var newIndex = new CollectionIndex(_owner, BuildFieldList(_owner, columns));
-            newIndex.Rebuild();
             _indexes.Add(newIndex);
             return newIndex;
         }

--- a/src/OneScript.StandardLibrary/Collections/ValueTable/CollectionIndexes.cs
+++ b/src/OneScript.StandardLibrary/Collections/ValueTable/CollectionIndexes.cs
@@ -40,7 +40,7 @@ namespace OneScript.StandardLibrary.Collections.ValueTable
         [ContextMethod("Количество", "Count")]
         public override int Count()
         {
-            return _indexes.Count();
+            return _indexes.Count;
         }
 
         [ContextMethod("Удалить", "Delete")]
@@ -130,21 +130,18 @@ namespace OneScript.StandardLibrary.Collections.ValueTable
             return _indexes.FirstOrDefault(index => index.CanBeUsedFor(searchFields));
         }
 
-        private static IList<IValue> BuildFieldList(IIndexCollectionSource source, string fieldList)
+        private static List<IValue> BuildFieldList(IIndexCollectionSource source, string fieldList)
         {
             var fields = new List<IValue>();
-            var fieldNames = fieldList.Split(',');
+            if (string.IsNullOrEmpty(fieldList))
+                return fields;
+
+            var fieldNames = fieldList.Split(',', System.StringSplitOptions.RemoveEmptyEntries);
             foreach (var fieldName in fieldNames)
             {
-                if (!string.IsNullOrWhiteSpace(fieldName))
-                {
-                    var field = source.GetField(fieldName.Trim());
-                    if (field == null)
-                    {
-                        throw ColumnException.WrongColumnName(fieldName);
-                    }
-                    fields.Add(field);
-                }
+                var name = fieldName.Trim();
+                var field = source.GetField(name) ?? throw ColumnException.WrongColumnName(fieldName);
+                fields.Add(field);
             }
 
             return fields;

--- a/src/OneScript.StandardLibrary/Collections/ValueTable/CollectionIndexes.cs
+++ b/src/OneScript.StandardLibrary/Collections/ValueTable/CollectionIndexes.cs
@@ -45,12 +45,17 @@ namespace OneScript.StandardLibrary.Collections.ValueTable
         [ContextMethod("Удалить", "Delete")]
         public void Delete(IValue index)
         {
-            _indexes.Remove(GetIndex(index));
+            var idx = GetIndex(index);
+            idx.ExcludeFields();
+            _indexes.Remove(idx);
         }
 
         [ContextMethod("Очистить", "Clear")]
         public void Clear()
         {
+            foreach (var idx in _indexes)
+                idx.ExcludeFields();
+
             _indexes.Clear();
         }
 

--- a/src/OneScript.StandardLibrary/Collections/ValueTable/ValueTable.cs
+++ b/src/OneScript.StandardLibrary/Collections/ValueTable/ValueTable.cs
@@ -70,7 +70,8 @@ namespace OneScript.StandardLibrary.Collections.ValueTable
         {
             var row = new ValueTableRow(this);
             _rows.Add(row);
-            Indexes.ElementAdded(row);
+            if (Indexes.Count() > 0) 
+                Indexes.ElementAdded(row);
             return row;
         }
 
@@ -157,7 +158,7 @@ namespace OneScript.StandardLibrary.Collections.ValueTable
             return result;
         }
 
-        private List<ValueTableColumn> GetProcessingColumnList(string columnNames, bool emptyListInCaseOfNull = false)
+         private List<ValueTableColumn> GetProcessingColumnList(string columnNames, bool emptyListInCaseOfNull = false)
         {
             var processing_list = new List<ValueTableColumn>();
             if (string.IsNullOrEmpty(columnNames)) // Передали пустую строку вместо списка колонок
@@ -313,15 +314,17 @@ namespace OneScript.StandardLibrary.Collections.ValueTable
             }
             return ValueFactory.Create();
         }
+ 
+        private ValueTableColumn GetColumnOrThrow(string column_name)
+            => this.Columns.FindColumnByName(column_name)
+                ?? throw ColumnException.WrongColumnName(column_name);
+
 
         private bool CheckFilterCriteria(ValueTableRow Row, StructureImpl Filter)
         {
             foreach (var kv in Filter)
             {
-                var Column = Columns.FindColumnByName(kv.Key.ToString());
-                if (Column == null)
-                    throw ColumnException.WrongColumnName(kv.Key.ToString());
-
+                var Column = GetColumnOrThrow(kv.Key.ToString());
                 IValue current = Row.Get(Column);
                 if (!current.StrictEquals(kv.Value))
                     return false;
@@ -361,10 +364,7 @@ namespace OneScript.StandardLibrary.Collections.ValueTable
             var result = new MapImpl();
             foreach (var kv in filter)
             {
-                var key = Columns.FindColumnByName(kv.Key.ToString());
-                if (key == null)
-                    throw ColumnException.WrongColumnName(kv.Key.ToString());
-
+                var key = GetColumnOrThrow(kv.Key.ToString());
                 result.Insert(key, kv.Value);
             }
 
@@ -653,10 +653,7 @@ namespace OneScript.StandardLibrary.Collections.ValueTable
                 if (description.Length > 2)
                     throw RuntimeException.InvalidNthArgumentValue(1);
 
-                var sortColumn = this.Columns.FindColumnByName(description[0]);
-                if (sortColumn == null)
-                    throw ColumnException.WrongColumnName(description[0]);
-
+                var sortColumn = GetColumnOrThrow(description[0]);
                 var rule = new ValueTableSortRule
                 {
                     Column = sortColumn,

--- a/src/OneScript.StandardLibrary/Collections/ValueTable/ValueTable.cs
+++ b/src/OneScript.StandardLibrary/Collections/ValueTable/ValueTable.cs
@@ -84,13 +84,14 @@ namespace OneScript.StandardLibrary.Collections.ValueTable
         [ContextMethod("Вставить", "Insert")]
         public ValueTableRow Insert(int index)
         {
-            var row = new ValueTableRow(this);
             if (index < 0 || index > _rows.Count)
-                _rows.Add(row); // для совместимости с 1С, хотя логичней было бы исключение
-            else
-                _rows.Insert(index, row);
+                return Add(); // для совместимости с 1С, хотя логичней было бы исключение
 
-            Indexes.ElementAdded(row);
+            var row = new ValueTableRow(this);
+            _rows.Insert(index, row);
+
+            if (Indexes.Count() > 0)
+                Indexes.ElementAdded(row);
             return row;
         }
 
@@ -347,7 +348,7 @@ namespace OneScript.StandardLibrary.Collections.ValueTable
 
             var mapped = ColumnsMap(filter);
             var suitableIndex = Indexes.FindSuitableIndex(mapped.Keys());
-            var dataToScan = suitableIndex != null ? suitableIndex.GetData(mapped) : _rows;
+            var dataToScan = suitableIndex?.GetData(mapped) ?? _rows;
 
             foreach (var element in dataToScan)
             {

--- a/src/OneScript.StandardLibrary/Collections/ValueTable/ValueTableColumn.cs
+++ b/src/OneScript.StandardLibrary/Collections/ValueTable/ValueTableColumn.cs
@@ -24,7 +24,7 @@ namespace OneScript.StandardLibrary.Collections.ValueTable
         private readonly TypeDescription _valueType;
         private readonly WeakReference _owner;
 
-        public bool IsIndexable { get; set; }
+        public bool IsIndexable { get; internal set; }
         
         public ValueTableColumn(ValueTableColumnCollection owner, string name, string title, TypeDescription type, int width)
         {

--- a/src/OneScript.StandardLibrary/Collections/ValueTable/ValueTableColumn.cs
+++ b/src/OneScript.StandardLibrary/Collections/ValueTable/ValueTableColumn.cs
@@ -21,17 +21,18 @@ namespace OneScript.StandardLibrary.Collections.ValueTable
     {
         private string _title;
         private string _name;
-        private TypeDescription _valueType;
+        private readonly TypeDescription _valueType;
         private readonly WeakReference _owner;
-        private readonly int _id;
+
+        public bool IsIndexable { get; set; }
         
-        public ValueTableColumn(ValueTableColumnCollection owner, int id, string name, string title, TypeDescription type, int width)
+        public ValueTableColumn(ValueTableColumnCollection owner, string name, string title, TypeDescription type, int width)
         {
             _name = name;
             _title = title;
             _valueType = type ?? new TypeDescription();
             Width = width;
-            _id = id;
+            IsIndexable = false;
 
             _owner = new WeakReference(owner);
         }
@@ -65,7 +66,6 @@ namespace OneScript.StandardLibrary.Collections.ValueTable
                     _title = value;
 
                 _name = value;
-
             }
         }
         /// <summary>

--- a/src/OneScript.StandardLibrary/Collections/ValueTable/ValueTableColumn.cs
+++ b/src/OneScript.StandardLibrary/Collections/ValueTable/ValueTableColumn.cs
@@ -24,15 +24,17 @@ namespace OneScript.StandardLibrary.Collections.ValueTable
         private readonly TypeDescription _valueType;
         private readonly WeakReference _owner;
 
-        public bool IsIndexable { get; internal set; }
-        
+        private int _indicesCount = 0;
+        public bool IsIndexable => _indicesCount != 0;
+        public void AddToIndex() { _indicesCount++; }
+        public void DeleteFromIndex() { if (_indicesCount != 0) _indicesCount--; }
+
         public ValueTableColumn(ValueTableColumnCollection owner, string name, string title, TypeDescription type, int width)
         {
             _name = name;
             _title = title;
             _valueType = type ?? new TypeDescription();
             Width = width;
-            IsIndexable = false;
 
             _owner = new WeakReference(owner);
         }

--- a/src/OneScript.StandardLibrary/Collections/ValueTable/ValueTableColumnCollection.cs
+++ b/src/OneScript.StandardLibrary/Collections/ValueTable/ValueTableColumnCollection.cs
@@ -25,8 +25,9 @@ namespace OneScript.StandardLibrary.Collections.ValueTable
     [ContextClass("КоллекцияКолонокТаблицыЗначений", "ValueTableColumnCollection")]
     public class ValueTableColumnCollection : AutoContext<ValueTableColumnCollection>, ICollectionContext<ValueTableColumn>, IDebugPresentationAcceptor
     {
+        private static readonly StringComparer _namesComparer = StringComparer.OrdinalIgnoreCase;
+
         private readonly List<ValueTableColumn> _columns = new List<ValueTableColumn>();
-        private readonly StringComparer _namesComparer = StringComparer.OrdinalIgnoreCase;
         private readonly ValueTable _owner;
 
         public ValueTableColumnCollection(ValueTable owner)
@@ -40,6 +41,14 @@ namespace OneScript.StandardLibrary.Collections.ValueTable
             _columns.Add(column);
             return column;
         }
+
+        public ValueTableColumn AddUnchecked(string name, string title = null)
+        {
+            var column = new ValueTableColumn(this, name, title ?? name, null, 0);
+            _columns.Add(column);
+            return column;
+        }
+
 
         private void CheckColumnName(string name)
         {

--- a/src/OneScript.StandardLibrary/Collections/ValueTable/ValueTableColumnCollection.cs
+++ b/src/OneScript.StandardLibrary/Collections/ValueTable/ValueTableColumnCollection.cs
@@ -28,11 +28,26 @@ namespace OneScript.StandardLibrary.Collections.ValueTable
         private readonly List<ValueTableColumn> _columns = new List<ValueTableColumn>();
         private readonly StringComparer _namesComparer = StringComparer.OrdinalIgnoreCase;
         private readonly ValueTable _owner;
-        private int maxColumnId = 0;
 
         public ValueTableColumnCollection(ValueTable owner)
         {
             _owner = owner;
+        }
+
+        public ValueTableColumn AddUnchecked(string name, string title, TypeDescription type = null)
+        {
+            var column = new ValueTableColumn(this, name, title, type, 0);
+            _columns.Add(column);
+            return column;
+        }
+
+        private void CheckColumnName(string name)
+        {
+            if (!Utils.IsValidIdentifier(name))
+                throw ColumnException.WrongColumnName(name);
+
+            if (FindColumnByName(name) != null)
+                throw ColumnException.DuplicatedColumnName(name);
         }
 
         /// <summary>
@@ -46,13 +61,9 @@ namespace OneScript.StandardLibrary.Collections.ValueTable
         [ContextMethod("Добавить", "Add")]
         public ValueTableColumn Add(string name, TypeDescription type = null, string title = null, int width = 0)
         {
-            if (!Utils.IsValidIdentifier(name))
-                throw ColumnException.WrongColumnName(name);
+            CheckColumnName(name);
 
-            if (FindColumnByName(name) != null)
-                throw ColumnException.DuplicatedColumnName(name);
-
-            var column = new ValueTableColumn(this, ++maxColumnId, name, title, type, width);
+            var column = new ValueTableColumn(this, name, title, type, width);
             _columns.Add(column);
 
             return column;
@@ -70,13 +81,9 @@ namespace OneScript.StandardLibrary.Collections.ValueTable
         [ContextMethod("Вставить", "Insert")]
         public ValueTableColumn Insert(int index, string name, TypeDescription type = null, string title = null, int width = 0)
         {
-            if (!Utils.IsValidIdentifier(name))
-                throw ColumnException.WrongColumnName(name);
+            CheckColumnName(name);
 
-            if (FindColumnByName(name) != null)
-                throw ColumnException.DuplicatedColumnName(name);
-
-            ValueTableColumn column = new ValueTableColumn(this, ++maxColumnId, name, title, type, width);
+            ValueTableColumn column = new ValueTableColumn(this, name, title, type, width);
             _columns.Insert(index, column);
 
             return column;
@@ -113,10 +120,7 @@ namespace OneScript.StandardLibrary.Collections.ValueTable
         [ContextMethod("Найти", "Find")]
         public IValue Find(string name)
         {
-            ValueTableColumn Column = FindColumnByName(name);
-            if (Column == null)
-                return ValueFactory.Create();
-            return Column;
+            return FindColumnByName(name) ?? ValueFactory.Create();
         }
 
         /// <summary>

--- a/src/OneScript.StandardLibrary/Collections/ValueTable/ValueTableRow.cs
+++ b/src/OneScript.StandardLibrary/Collections/ValueTable/ValueTableRow.cs
@@ -89,9 +89,14 @@ namespace OneScript.StandardLibrary.Collections.ValueTable
 
         public void Set(ValueTableColumn column, IValue value)
         {
-            _owner.Indexes.ElementRemoved(this);
-            _data[column] = column.ValueType.AdjustValue(value);
-            _owner.Indexes.ElementAdded(this);
+            if (column.IsIndexable)
+            {
+                _owner.Indexes.ElementRemoved(this);
+                _data[column] = column.ValueType.AdjustValue(value);
+                _owner.Indexes.ElementAdded(this);
+            }
+            else
+                _data[column] = column.ValueType.AdjustValue(value);
         }
 
         public void OnOwnerColumnRemoval(ValueTableColumn column)

--- a/src/OneScript.StandardLibrary/Collections/ValueTable/ValueTableRow.cs
+++ b/src/OneScript.StandardLibrary/Collections/ValueTable/ValueTableRow.cs
@@ -24,11 +24,8 @@ namespace OneScript.StandardLibrary.Collections.ValueTable
             _owner = owner;
         }
 
-        public int Count()
-        {
-            return _owner.Columns.Count();
-        }
-        
+        public int Count() => _owner.Columns.Count();
+
         public int Count(IBslProcess process) => Count();
         
         /// <summary>

--- a/src/OneScript.StandardLibrary/Reflector.cs
+++ b/src/OneScript.StandardLibrary/Reflector.cs
@@ -141,11 +141,14 @@ namespace OneScript.StandardLibrary
             }
         }
 
+
+        private const int annotNameColumnIndex = 0;
+        private const int annotParamsColumnIndex = 1;
         private static ValueTable EmptyAnnotationsTable()
         {
             var annotationsTable = new ValueTable();
-            annotationsTable.Columns.Add("Имя");
-            annotationsTable.Columns.Add("Параметры");
+            annotationsTable.Columns.AddUnchecked("Имя","Имя");
+            annotationsTable.Columns.AddUnchecked("Параметры", "Параметры");
 
             return annotationsTable;
         }
@@ -153,8 +156,8 @@ namespace OneScript.StandardLibrary
         private static ValueTable CreateAnnotationTable(BslAnnotationAttribute[] annotations)
         {
             var annotationsTable = EmptyAnnotationsTable();
-            var annotationNameColumn = annotationsTable.Columns.FindColumnByName("Имя");
-            var annotationParamsColumn = annotationsTable.Columns.FindColumnByName("Параметры");
+            var annotationNameColumn = annotationsTable.Columns.FindColumnByIndex(annotNameColumnIndex);
+            var annotationParamsColumn = annotationsTable.Columns.FindColumnByIndex(annotParamsColumnIndex);
 
             foreach (var annotation in annotations)
             {
@@ -186,9 +189,10 @@ namespace OneScript.StandardLibrary
                 if (annotationParameter.Value is BslAnnotationValue annotationValue)
                 {
                     var expandedValue = EmptyAnnotationsTable();
+                    var expandedValueColumns = expandedValue.Columns;
                     var row = expandedValue.Add();
-                    row.Set(expandedValue.Columns.FindColumnByName("Имя"), ValueFactory.Create(annotationValue.Name));
-                    row.Set(expandedValue.Columns.FindColumnByName("Параметры"), FillAnnotationParameters(annotationValue.Parameters));
+                    row.Set(expandedValueColumns.FindColumnByIndex(annotNameColumnIndex), ValueFactory.Create(annotationValue.Name));
+                    row.Set(expandedValueColumns.FindColumnByIndex(annotParamsColumnIndex), FillAnnotationParameters(annotationValue.Parameters));
                     parameterRow.Set(parameterValueColumn, row);
                 }
                 else
@@ -344,12 +348,12 @@ namespace OneScript.StandardLibrary
 
         private static void FillMethodsTable(ValueTable result, IEnumerable<BslMethodInfo> methods)
         {
-            var nameColumn = result.Columns.Add("Имя", TypeDescription.StringType(), "Имя");
-            var countColumn = result.Columns.Add("КоличествоПараметров", TypeDescription.IntegerType(), "Количество параметров");
-            var isFunctionColumn = result.Columns.Add("ЭтоФункция", TypeDescription.BooleanType(), "Это функция");
-            var annotationsColumn = result.Columns.Add("Аннотации", new TypeDescription(), "Аннотации");
-            var paramsColumn = result.Columns.Add("Параметры", new TypeDescription(), "Параметры");
-            var isExportlColumn = result.Columns.Add("Экспорт", TypeDescription.BooleanType(), "Экспорт");
+            var nameColumn = result.Columns.AddUnchecked("Имя", "Имя", TypeDescription.StringType());
+            var countColumn = result.Columns.AddUnchecked("КоличествоПараметров", "Количество параметров", TypeDescription.IntegerType());
+            var isFunctionColumn = result.Columns.AddUnchecked("ЭтоФункция", "Это функция", TypeDescription.BooleanType());
+            var annotationsColumn = result.Columns.AddUnchecked("Аннотации", "Аннотации");
+            var paramsColumn = result.Columns.AddUnchecked("Параметры", "Параметры");
+            var isExportlColumn = result.Columns.AddUnchecked("Экспорт", "Экспорт", TypeDescription.BooleanType());
 
             foreach (var methInfo in methods)
             {
@@ -365,12 +369,11 @@ namespace OneScript.StandardLibrary
                 new_row.Set(annotationsColumn, CreateAnnotationTable(annotations));
 
                 var paramTable = new ValueTable();
-                var paramNameColumn = paramTable.Columns.Add("Имя", TypeDescription.StringType(), "Имя");
-                var paramByValue = paramTable.Columns.Add("ПоЗначению", TypeDescription.BooleanType(), "По значению");
-                var paramHasDefaultValue = paramTable.Columns.Add("ЕстьЗначениеПоУмолчанию", TypeDescription.BooleanType(), "Есть значение по-умолчанию");
-                var paramDefaultValue = paramTable.Columns.Add("ЗначениеПоУмолчанию", new TypeDescription(), "Значение по умолчанию");
-                var paramAnnotationsColumn = paramTable.Columns.Add("Аннотации", new TypeDescription(), "Аннотации");
-
+                var paramNameColumn = paramTable.Columns.AddUnchecked("Имя", "Имя", TypeDescription.StringType());
+                var paramByValue = paramTable.Columns.AddUnchecked("ПоЗначению", "По значению", TypeDescription.BooleanType());
+                var paramHasDefaultValue = paramTable.Columns.AddUnchecked("ЕстьЗначениеПоУмолчанию", "Есть значение по-умолчанию", TypeDescription.BooleanType());
+                var paramDefaultValue = paramTable.Columns.AddUnchecked("ЗначениеПоУмолчанию", "Значение по умолчанию");
+                var paramAnnotationsColumn = paramTable.Columns.AddUnchecked("Аннотации", "Аннотации");
                 new_row.Set(paramsColumn, paramTable);
 
                 if (parameters.Length != 0)
@@ -454,9 +457,9 @@ namespace OneScript.StandardLibrary
 
         private static void FillPropertiesTable(ValueTable result, IEnumerable<BslPropertyInfo> properties)
         {
-            var nameColumn = result.Columns.Add("Имя", TypeDescription.StringType(), "Имя");
-            var annotationsColumn = result.Columns.Add("Аннотации", new TypeDescription(), "Аннотации");
-            var isExportedColumn = result.Columns.Add("Экспорт", TypeDescription.BooleanType(), "Экспорт");
+            var nameColumn = result.Columns.AddUnchecked("Имя", "Имя", TypeDescription.StringType());
+            var annotationsColumn = result.Columns.AddUnchecked("Аннотации", "Аннотации");
+            var isExportedColumn = result.Columns.AddUnchecked("Экспорт", "Экспорт", TypeDescription.BooleanType());
             
             var systemVarNames = new string[] { "этотобъект", "thisobject" };
 
@@ -532,11 +535,11 @@ namespace OneScript.StandardLibrary
         {
             var result = new ValueTable();
             
-            var nameColumn = result.Columns.Add("Имя", TypeDescription.StringType());
-            var valueColumn = result.Columns.Add("Значение", new TypeDescription(new List<BslTypeValue>() { new BslTypeValue(BasicTypes.Type) }));
-            var primitiveColumn = result.Columns.Add("Примитивный", TypeDescription.BooleanType());
-            var userColumn = result.Columns.Add("Пользовательский", TypeDescription.BooleanType());
-            var collectionColumn = result.Columns.Add("Коллекция", TypeDescription.BooleanType());
+            var nameColumn = result.Columns.AddUnchecked("Имя", "Имя", TypeDescription.StringType());
+            var valueColumn = result.Columns.AddUnchecked("Значение", "Значение", new TypeDescription(new[] { new BslTypeValue(BasicTypes.Type) }));
+            var primitiveColumn = result.Columns.AddUnchecked("Примитивный", "Примитивный", TypeDescription.BooleanType());
+            var userColumn = result.Columns.AddUnchecked("Пользовательский", "Пользовательский", TypeDescription.BooleanType());
+            var collectionColumn = result.Columns.AddUnchecked("Коллекция", "Коллекция", TypeDescription.BooleanType());
             
             _typeManager.RegisteredTypes().ForEach(descriptor =>
             {

--- a/src/OneScript.StandardLibrary/Reflector.cs
+++ b/src/OneScript.StandardLibrary/Reflector.cs
@@ -28,7 +28,7 @@ namespace OneScript.StandardLibrary
     /// Как правило, рефлексия используется для проверки наличия у объекта определенных свойств/методов.
     /// В OneScript рефлексию можно применять для вызова методов объектов по именам методов.
     /// </summary>
-    [ContextClass("Рефлектор","Reflector")]
+    [ContextClass("Рефлектор", "Reflector")]
     public class ReflectorContext : AutoContext<ReflectorContext>
     {
         private readonly ITypeManager _typeManager;
@@ -56,7 +56,7 @@ namespace OneScript.StandardLibrary
                 argsToPass = arguments?.ToArray() ?? Array.Empty<IValue>();
             else
                 argsToPass = GetArgsToPass(arguments, methInfo.GetBslParameters());
- 
+
             IValue retValue = ValueFactory.Create();
             if (methInfo.IsFunction())
             {
@@ -85,7 +85,7 @@ namespace OneScript.StandardLibrary
         {
             var argValues = arguments?.ToArray() ?? Array.Empty<IValue>();
             // ArrayImpl не может (не должен!) содержать null или NotAValidValue
-            
+
             if (argValues.Length > parameters.Length)
                 throw RuntimeException.TooManyArgumentsPassed();
 
@@ -119,7 +119,7 @@ namespace OneScript.StandardLibrary
         [ContextMethod("МетодСуществует", "MethodExists")]
         public bool MethodExists(BslValue target, string methodName)
         {
-            if(target is BslObjectValue)
+            if (target is BslObjectValue)
                 return MethodExistsForObject(target.AsObject(), methodName);
 
             if (target.SystemType == BasicTypes.Type)
@@ -147,8 +147,8 @@ namespace OneScript.StandardLibrary
         private static ValueTable EmptyAnnotationsTable()
         {
             var annotationsTable = new ValueTable();
-            annotationsTable.Columns.AddUnchecked("Имя","Имя");
-            annotationsTable.Columns.AddUnchecked("Параметры", "Параметры");
+            annotationsTable.Columns.AddUnchecked("Имя");
+            annotationsTable.Columns.AddUnchecked("Параметры");
 
             return annotationsTable;
         }
@@ -201,7 +201,7 @@ namespace OneScript.StandardLibrary
                 }
             }
 
-           return parametersTable;
+            return parametersTable;
         }
 
         private static bool MethodExistsForType(BslTypeValue type, string methodName)
@@ -213,7 +213,7 @@ namespace OneScript.StandardLibrary
         private static Type GetReflectableClrType(BslTypeValue type)
         {
             var clrType = type.TypeValue.ImplementingClass;
-            if(clrType != typeof(AttachedScriptsFactory) && !typeof(IRuntimeContextInstance).IsAssignableFrom(clrType))
+            if (clrType != typeof(AttachedScriptsFactory) && !typeof(IRuntimeContextInstance).IsAssignableFrom(clrType))
             {
                 throw NonReflectableType();
             }
@@ -241,7 +241,7 @@ namespace OneScript.StandardLibrary
         public ValueTable GetMethodsTable(BslValue target)
         {
             var result = new ValueTable();
-            if(target is BslObjectValue)
+            if (target is BslObjectValue)
                 FillMethodsTableForObject(target.AsObject(), result);
             else if (target.SystemType == BasicTypes.Type)
                 FillMethodsTableForType(target as BslTypeValue, result);
@@ -259,7 +259,7 @@ namespace OneScript.StandardLibrary
         private static void FillMethodsTableForType(BslTypeValue type, ValueTable result)
         {
             var clrType = GetReflectableClrType(type);
-            var clrMethods = clrType.GetMethods(BindingFlags.Instance|BindingFlags.NonPublic|BindingFlags.Public);
+            var clrMethods = clrType.GetMethods(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
             FillMethodsTable(result, clrMethods.Cast<BslMethodInfo>());
         }
 
@@ -268,12 +268,12 @@ namespace OneScript.StandardLibrary
             if (target is ScriptDrivenObject scriptObject)
             {
                 var fieldsQuery = scriptObject.Module.Fields.Cast<BslScriptFieldInfo>();
-                
+
                 if (!withPrivate)
                 {
                     fieldsQuery = fieldsQuery.Where(x => x.IsPublic);
-                }    
-                
+                }
+
                 var fields = fieldsQuery.Select(field => BslPropertyBuilder.Create()
                             .Name(field.Name)
                             .IsExported(field.IsPublic)
@@ -283,10 +283,10 @@ namespace OneScript.StandardLibrary
                         )
                     .OrderBy(p => p.DispatchId)
                     .ToArray();
-                
+
                 var fieldNames = fields.Select(x => x.Name)
                     .ToHashSet();
-                
+
                 var properties = scriptObject.GetProperties()
                     .Where(prop => !fieldNames.Contains(prop.Name));
 
@@ -295,7 +295,7 @@ namespace OneScript.StandardLibrary
                     properties = properties.OfType<BslScriptPropertyInfo>()
                         .Where(p => p.IsExported);
                 }
-                
+
                 FillPropertiesTable(result, properties.Concat(fields));
             }
             else
@@ -304,7 +304,7 @@ namespace OneScript.StandardLibrary
                 FillPropertiesTable(result, objectProperties);
             }
         }
-        
+
         private static void FillPropertiesTableForType(BslTypeValue type, ValueTable result, bool withPrivate)
         {
             var clrType = GetReflectableClrType(type);
@@ -314,7 +314,7 @@ namespace OneScript.StandardLibrary
                                          PropDef = x.GetCustomAttribute<ContextPropertyAttribute>(),
                                          Prop = x
                                      })
-                                     .Where(x=>x.PropDef != null)
+                                     .Where(x => x.PropDef != null)
                                      .Select(x => new ContextPropertyInfo(x.Prop));
 
             var infos = new List<BslPropertyInfo>();
@@ -324,12 +324,12 @@ namespace OneScript.StandardLibrary
 
             if (typeof(ScriptDrivenObject).IsAssignableFrom(clrType.BaseType))
             {
-                var flags = BindingFlags.Instance|BindingFlags.Public;
+                var flags = BindingFlags.Instance | BindingFlags.Public;
                 if (withPrivate)
                     flags |= BindingFlags.NonPublic;
 
                 var nativeFields = clrType.GetFields(flags);
-                foreach(var field in nativeFields)
+                foreach (var field in nativeFields)
                 {
                     var prop = BslPropertyBuilder.Create()
                         .Name(field.Name)
@@ -337,7 +337,7 @@ namespace OneScript.StandardLibrary
                         .SetDispatchingIndex(indices++)
                         .SetAnnotations(field.GetAnnotations())
                         .Build();
-                    
+
                     infos.Add(prop);
                 }
             }
@@ -348,18 +348,18 @@ namespace OneScript.StandardLibrary
 
         private static void FillMethodsTable(ValueTable result, IEnumerable<BslMethodInfo> methods)
         {
-            var nameColumn = result.Columns.AddUnchecked("Имя", "Имя", TypeDescription.StringType());
-            var countColumn = result.Columns.AddUnchecked("КоличествоПараметров", "Количество параметров", TypeDescription.IntegerType());
-            var isFunctionColumn = result.Columns.AddUnchecked("ЭтоФункция", "Это функция", TypeDescription.BooleanType());
-            var annotationsColumn = result.Columns.AddUnchecked("Аннотации", "Аннотации");
-            var paramsColumn = result.Columns.AddUnchecked("Параметры", "Параметры");
-            var isExportlColumn = result.Columns.AddUnchecked("Экспорт", "Экспорт", TypeDescription.BooleanType());
+            var nameColumn = result.Columns.AddUnchecked("Имя");
+            var countColumn = result.Columns.AddUnchecked("КоличествоПараметров", "Количество параметров");
+            var isFunctionColumn = result.Columns.AddUnchecked("ЭтоФункция", "Это функция");
+            var annotationsColumn = result.Columns.AddUnchecked("Аннотации");
+            var paramsColumn = result.Columns.AddUnchecked("Параметры");
+            var isExportlColumn = result.Columns.AddUnchecked("Экспорт");
 
             foreach (var methInfo in methods)
             {
                 var annotations = methInfo.GetAnnotations();
                 var parameters = methInfo.GetBslParameters();
-                
+
                 ValueTableRow new_row = result.Add();
                 new_row.Set(nameColumn, ValueFactory.Create(methInfo.Name));
                 new_row.Set(countColumn, ValueFactory.Create(parameters.Length));
@@ -369,11 +369,11 @@ namespace OneScript.StandardLibrary
                 new_row.Set(annotationsColumn, CreateAnnotationTable(annotations));
 
                 var paramTable = new ValueTable();
-                var paramNameColumn = paramTable.Columns.AddUnchecked("Имя", "Имя", TypeDescription.StringType());
-                var paramByValue = paramTable.Columns.AddUnchecked("ПоЗначению", "По значению", TypeDescription.BooleanType());
-                var paramHasDefaultValue = paramTable.Columns.AddUnchecked("ЕстьЗначениеПоУмолчанию", "Есть значение по-умолчанию", TypeDescription.BooleanType());
+                var paramNameColumn = paramTable.Columns.AddUnchecked("Имя");
+                var paramByValue = paramTable.Columns.AddUnchecked("ПоЗначению", "По значению");
+                var paramHasDefaultValue = paramTable.Columns.AddUnchecked("ЕстьЗначениеПоУмолчанию", "Есть значение по-умолчанию");
                 var paramDefaultValue = paramTable.Columns.AddUnchecked("ЗначениеПоУмолчанию", "Значение по умолчанию");
-                var paramAnnotationsColumn = paramTable.Columns.AddUnchecked("Аннотации", "Аннотации");
+                var paramAnnotationsColumn = paramTable.Columns.AddUnchecked("Аннотации");
                 new_row.Set(paramsColumn, paramTable);
 
                 if (parameters.Length != 0)
@@ -404,7 +404,7 @@ namespace OneScript.StandardLibrary
         {
             var result = new ValueTable();
 
-            if(target is BslObjectValue)
+            if (target is BslObjectValue)
                 FillPropertiesTableForObject(result, target, withPrivate);
             else if (target.SystemType == BasicTypes.Type)
             {
@@ -457,10 +457,10 @@ namespace OneScript.StandardLibrary
 
         private static void FillPropertiesTable(ValueTable result, IEnumerable<BslPropertyInfo> properties)
         {
-            var nameColumn = result.Columns.AddUnchecked("Имя", "Имя", TypeDescription.StringType());
-            var annotationsColumn = result.Columns.AddUnchecked("Аннотации", "Аннотации");
-            var isExportedColumn = result.Columns.AddUnchecked("Экспорт", "Экспорт", TypeDescription.BooleanType());
-            
+            var nameColumn = result.Columns.AddUnchecked("Имя");
+            var annotationsColumn = result.Columns.AddUnchecked("Аннотации");
+            var isExportedColumn = result.Columns.AddUnchecked("Экспорт");
+
             var systemVarNames = new string[] { "этотобъект", "thisobject" };
 
             foreach (var propInfo in properties)
@@ -534,17 +534,17 @@ namespace OneScript.StandardLibrary
         public ValueTable KnownTypes(StructureImpl filter = default)
         {
             var result = new ValueTable();
-            
-            var nameColumn = result.Columns.AddUnchecked("Имя", "Имя", TypeDescription.StringType());
-            var valueColumn = result.Columns.AddUnchecked("Значение", "Значение", new TypeDescription(new[] { new BslTypeValue(BasicTypes.Type) }));
-            var primitiveColumn = result.Columns.AddUnchecked("Примитивный", "Примитивный", TypeDescription.BooleanType());
-            var userColumn = result.Columns.AddUnchecked("Пользовательский", "Пользовательский", TypeDescription.BooleanType());
-            var collectionColumn = result.Columns.AddUnchecked("Коллекция", "Коллекция", TypeDescription.BooleanType());
-            
+
+            var nameColumn = result.Columns.AddUnchecked("Имя");
+            var valueColumn = result.Columns.AddUnchecked("Значение");
+            var primitiveColumn = result.Columns.AddUnchecked("Примитивный");
+            var userColumn = result.Columns.AddUnchecked("Пользовательский");
+            var collectionColumn = result.Columns.AddUnchecked("Коллекция");
+
             _typeManager.RegisteredTypes().ForEach(descriptor =>
             {
                 var row = result.Add();
-                
+
                 row.Set(nameColumn, ValueFactory.Create(descriptor.ToString()));
                 row.Set(valueColumn, new BslTypeValue(descriptor));
                 row.Set(primitiveColumn, ValueFactory.Create(descriptor.ImplementingClass.IsSubclassOf(typeof(BslPrimitiveValue))));
@@ -558,7 +558,7 @@ namespace OneScript.StandardLibrary
             {
                 result = result.Copy(filter);
             }
-            
+
             return result;
         }
 

--- a/src/OneScript.StandardLibrary/TypeDescriptions/TypeComparer.cs
+++ b/src/OneScript.StandardLibrary/TypeDescriptions/TypeComparer.cs
@@ -14,7 +14,7 @@ namespace OneScript.StandardLibrary.TypeDescriptions
     internal class TypeComparer : IComparer<BslTypeValue>
     {
         private const string TYPE_BINARYDATA_NAME = "ДвоичныеДанные";
-        private static readonly IDictionary<TypeDescriptor, int> primitives = new Dictionary<TypeDescriptor, int>();
+        private static readonly Dictionary<TypeDescriptor, int> primitives = new Dictionary<TypeDescriptor, int>();
 
         public int Compare(BslTypeValue x, BslTypeValue y)
         {

--- a/src/OneScript.StandardLibrary/TypeDescriptions/TypeDescription.cs
+++ b/src/OneScript.StandardLibrary/TypeDescriptions/TypeDescription.cs
@@ -155,25 +155,33 @@ namespace OneScript.StandardLibrary.TypeDescriptions
 		public static TypeDescription StringType(int length = 0,
 			AllowedLengthEnum allowedLength = AllowedLengthEnum.Variable)
 		{
-			return TypeDescriptionBuilder.OfType(BasicTypes.String)
-				.SetStringQualifiers(new StringQualifiers(length, allowedLength))
-				.Build();
+            return new TypeDescription(new[] { new BslTypeValue(BasicTypes.String) },
+				new NumberQualifiers(),
+                new StringQualifiers(length, allowedLength),
+				new DateQualifiers(),
+				new BinaryDataQualifiers());
 		}
 
 		public static TypeDescription IntegerType(int length = 10,
 			AllowedSignEnum allowedSign = AllowedSignEnum.Any)
 		{
-			return TypeDescriptionBuilder.OfType(BasicTypes.Number)
-				.SetNumberQualifiers(new NumberQualifiers(length, 0, allowedSign))
-				.Build();
+            return new TypeDescription(new[] { new BslTypeValue(BasicTypes.Number) },
+                 new NumberQualifiers(length, 0, allowedSign),
+                 new StringQualifiers(),
+                 new DateQualifiers(),
+                 new BinaryDataQualifiers());
 		}
 
 		public static TypeDescription BooleanType()
 		{
-			return TypeDescriptionBuilder.OfType(BasicTypes.Boolean).Build();
-		}
+            return new TypeDescription(new[] { new BslTypeValue(BasicTypes.Boolean) },
+                  new NumberQualifiers(),
+                  new StringQualifiers(),
+                  new DateQualifiers(),
+                  new BinaryDataQualifiers());
+        }
 
-		[ScriptConstructor]
+        [ScriptConstructor]
 		public static TypeDescription Constructor(
 			TypeActivationContext context,
 			BslValue source = null,

--- a/src/OneScript.StandardLibrary/TypeDescriptions/TypeDescriptionBuilder.cs
+++ b/src/OneScript.StandardLibrary/TypeDescriptions/TypeDescriptionBuilder.cs
@@ -21,8 +21,9 @@ namespace OneScript.StandardLibrary.TypeDescriptions
         
         private const string TYPE_BINARYDATA_NAME = "ДвоичныеДанные";
 
-        private List<BslTypeValue> _types = new List<BslTypeValue>();
-        
+        private static readonly TypeComparer _comparer = new TypeComparer();
+        private readonly SortedSet<BslTypeValue> _types = new SortedSet<BslTypeValue>(_comparer);
+
         internal TypeDescriptionBuilder()
         {
         }
@@ -38,13 +39,20 @@ namespace OneScript.StandardLibrary.TypeDescriptions
 
         public TypeDescriptionBuilder AddTypes(IEnumerable<BslTypeValue> types)
         {
-            _types.AddRange(types);
+            foreach (var type in types)
+            {
+                if (type.TypeValue.ImplementingClass != typeof(BslUndefinedValue))
+                    _types.Add(type);
+            }
             return this;
         }
 
         public TypeDescriptionBuilder RemoveTypes(IEnumerable<BslTypeValue> types)
         {
-            _types.RemoveAll(types.Contains);
+            foreach (var type in types)
+            {
+                _types.Remove(type);
+            }
             return this;
         }
 
@@ -74,14 +82,11 @@ namespace OneScript.StandardLibrary.TypeDescriptions
 
         public TypeDescription Build()
         {
-            _types = new List<BslTypeValue>(_types.Distinct());
-            _types.RemoveAll(type => type.TypeValue.ImplementingClass == typeof(BslUndefinedValue));
-            _types.Sort(new TypeComparer());
             var hasNumber = _types.Any(type => type.TypeValue == BasicTypes.Number);
-            var hasString =_types.Any(type => type.TypeValue == BasicTypes.String);
+            var hasString = _types.Any(type => type.TypeValue == BasicTypes.String);
             var hasDate = _types.Any(type => type.TypeValue == BasicTypes.Date);
             var hasBinaryData = _types.Any(x => x.TypeValue.Name == TYPE_BINARYDATA_NAME);
-            
+
             if (!hasNumber || _numberQualifiers == null) _numberQualifiers = new NumberQualifiers();
             if (!hasString || _stringQualifiers == null) _stringQualifiers = new StringQualifiers();
             if (!hasDate || _dateQualifiers == null) _dateQualifiers = new DateQualifiers();


### PR DESCRIPTION
- классы, относящиеся к ТаблицеЗначений переработаны для ускорения в случае, когда индексов нет
- в Рефлекторе упрощено добавление колонок в разные таблицы

Нужны ли ОписанияТипов в таблицах, формируемых Рефлектором? Ведь запись в них не производится.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fewer spurious column-name errors and clearer missing-column reporting.
  * Prevented unnecessary index notifications when updating or inserting non-indexed data.

* **Improvements**
  * More reliable index lifecycle (add/remove/clear) and safer initial index rebuilding.
  * Centralized column creation/validation and consistent table/type construction.
  * Slight performance and behavior tweaks in row insertion, lookup and count handling.

* **Public API**
  * New column indexability controls and index-management methods introduced.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Speeds up ValueTable by avoiding unnecessary index updates via index-aware columns, simplifies Reflector table creation, and refactors TypeDescription building with a SortedSet-based comparer.
> 
> - **ValueTable / Indexing**:
>   - Make `ValueTableColumn` index-aware (`IsIndexable`, `AddToIndex`, `DeleteFromIndex`) and update `CollectionIndex` to manage column index refs and rebuild on init.
>   - Avoid index notifications when no indexes; clear/rebuild indexes in bulk ops (`Add`, `Insert`, `LoadColumn`, `FillValues`).
>   - Add `CollectionIndex.ExcludeFields`; ensure proper cleanup on index/collection delete/clear.
>   - Improve `FindRows` to use a suitable index (`suitableIndex?.GetData(...)`); add `GetColumnOrThrow` for consistent column lookup.
> - **Reflector**:
>   - Use `ValueTable.Columns.AddUnchecked(...)` for fast column setup; build annotation tables via column indices; unify property/method table schemas without explicit type descriptions.
> - **TypeDescriptions**:
>   - Replace list-based storage with `SortedSet` + `TypeComparer`; filter out `Undefined`.
>   - Simplify `TypeDescription.StringType/IntegerType/BooleanType` constructors; minor comparer/dictionary tweaks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 186a8bfa4f9b3d29a2511d32ecdc581b49456bf7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->