### PR TITLE
VM: имена свойств и методов в отдельный список

### DIFF
--- a/src/OneScript.Core/Contexts/ClassBuilder.cs
+++ b/src/OneScript.Core/Contexts/ClassBuilder.cs
@@ -111,9 +111,10 @@ namespace OneScript.Contexts
                   .Any(x => includeDeprecations || (x as ContextMethodAttribute)?.IsDeprecated == false);
         }
 
-        private static bool MarkedAsContextProperty(MemberInfo member, bool includeDeprecations = false)
+        private static bool MarkedAsContextProperty(PropertyInfo member, bool includeDeprecations = false)
         {
-            return member.GetCustomAttributes(typeof(ContextPropertyAttribute), false).Length != 0;
+            return member.GetCustomAttributes(typeof(ContextPropertyAttribute), false)
+                .Any(x => includeDeprecations || (x as ContextPropertyAttribute)?.IsDeprecated == false);
         }
 
         public ClassBuilder ExportConstructor(MethodInfo info)

--- a/src/OneScript.Core/Contexts/ClassBuilder.cs
+++ b/src/OneScript.Core/Contexts/ClassBuilder.cs
@@ -113,7 +113,7 @@ namespace OneScript.Contexts
 
         private static bool MarkedAsContextProperty(MemberInfo member, bool includeDeprecations = false)
         {
-            return member.GetCustomAttributes(typeof(ContextPropertyAttribute), false).Any();
+            return member.GetCustomAttributes(typeof(ContextPropertyAttribute), false).Length != 0;
         }
 
         public ClassBuilder ExportConstructor(MethodInfo info)

--- a/src/OneScript.Language/SyntaxAnalysis/BslSyntaxWalker.cs
+++ b/src/OneScript.Language/SyntaxAnalysis/BslSyntaxWalker.cs
@@ -324,7 +324,7 @@ namespace OneScript.Language.SyntaxAnalysis
 
         protected virtual void VisitModuleBody(BslSyntaxNode codeBlock)
         {
-            if(codeBlock.Children.Count > 0)
+            if(codeBlock.Children.Count != 0)
                 VisitCodeBlock(codeBlock.Children[0]);
         }
 

--- a/src/OneScript.Language/SyntaxAnalysis/ConditionalDirectiveHandler.cs
+++ b/src/OneScript.Language/SyntaxAnalysis/ConditionalDirectiveHandler.cs
@@ -297,7 +297,7 @@ namespace OneScript.Language.SyntaxAnalysis
 
         private void PopBlock()
         {
-            if (_blocks.Count > 0)
+            if (_blocks.Count != 0)
                 _blocks.Pop();
             else
                 AddError(LocalizedErrors.DirectiveIsMissing("Если"));

--- a/src/OneScript.Language/SyntaxAnalysis/DefaultBslParser.cs
+++ b/src/OneScript.Language/SyntaxAnalysis/DefaultBslParser.cs
@@ -123,7 +123,7 @@ namespace OneScript.Language.SyntaxAnalysis
                 .Cast<ModuleAnnotationDirectiveHandler>()
                 .ToList();
             
-            if (!annotationParser.Any())
+            if (annotationParser.Count == 0)
                 return;
 
             while (_lastExtractedLexem.Type == LexemType.PreprocessorDirective)
@@ -1650,7 +1650,7 @@ namespace OneScript.Language.SyntaxAnalysis
 
             if (doFastForward)
             {
-                if (_tokenStack.Count > 0)
+                if (_tokenStack.Count != 0)
                     SkipToNextStatement(_tokenStack.Peek());
                 else
                     SkipToNextStatement();

--- a/src/OneScript.Native/Compiler/MethodCompiler.cs
+++ b/src/OneScript.Native/Compiler/MethodCompiler.cs
@@ -713,7 +713,7 @@ namespace OneScript.Native.Compiler
                 {
                     stack.Push(elif);
                 }
-                else if (stack.Count > 0)
+                else if (stack.Count != 0)
                 {
                     var cond = stack.Pop();
 
@@ -726,7 +726,7 @@ namespace OneScript.Native.Compiler
                 }
             }
 
-            while (stack.Count > 0)
+            while (stack.Count != 0)
             {
                 var elseIfNode = stack.Pop();
                 VisitElseIfNode(elseIfNode);
@@ -1147,7 +1147,7 @@ namespace OneScript.Native.Compiler
         private IEnumerable<Expression> PrepareDynamicCallArguments(BslSyntaxNode argList)
         {
             return argList.Children.Select(passedArg =>
-                passedArg.Children.Count > 0
+                passedArg.Children.Count != 0
                     ? ConvertToExpressionTree(passedArg.Children[0])
                     : Expression.Constant(BslSkippedParameterValue.Instance));
         }
@@ -1414,7 +1414,7 @@ namespace OneScript.Native.Compiler
             }
 
             var parameters = argList.Children.Select(passedArg =>
-                passedArg.Children.Count > 0
+                passedArg.Children.Count != 0
                     ? ConvertToExpressionTree(passedArg.Children[0])
                     : null).ToArray();
 
@@ -1523,7 +1523,7 @@ namespace OneScript.Native.Compiler
             if (node.ConstructorArguments != default)
             {
                 parameters = node.ConstructorArguments.Children.Select(passedArg => 
-                    passedArg.Children.Count > 0 ? 
+                    passedArg.Children.Count != 0 ? 
                         ConvertToExpressionTree(passedArg.Children[0]) :
                         Expression.Default(typeof(BslValue))).ToArray();
             }

--- a/src/OneScript.Native/Compiler/StatementBlocksWriter.cs
+++ b/src/OneScript.Native/Compiler/StatementBlocksWriter.cs
@@ -18,7 +18,7 @@ namespace OneScript.Native.Compiler
 
         public void EnterBlock(JumpInformationRecord newJumpStates)
         {
-            var current = _blocks.Count > 0 ? GetCurrentBlock() : null;
+            var current = _blocks.Count != 0 ? GetCurrentBlock() : null;
             if (current != null)
             {
                 newJumpStates.MethodReturn ??= current.MethodReturn;

--- a/src/OneScript.StandardLibrary/Collections/Indexes/CollectionIndex.cs
+++ b/src/OneScript.StandardLibrary/Collections/Indexes/CollectionIndex.cs
@@ -42,7 +42,7 @@ namespace OneScript.StandardLibrary.Collections.Indexes
 
         internal bool CanBeUsedFor(IEnumerable<IValue> searchFields)
         {
-            return _fields.Count > 0 && _fields.All(f => searchFields.Contains(f));
+            return _fields.Count != 0 && _fields.All(f => searchFields.Contains(f));
         }
 
         private CollectionIndexKey IndexKey(PropertyNameIndexAccessor source)

--- a/src/OneScript.StandardLibrary/CustomLineFeedStreamReader.cs
+++ b/src/OneScript.StandardLibrary/CustomLineFeedStreamReader.cs
@@ -56,7 +56,7 @@ namespace OneScript.StandardLibrary
                 _buffer.Dequeue ();
                 UpdateCharQueue ();
 
-                if (_buffer.Count > 0 && _buffer.Peek () == '\n') {
+                if (_buffer.Count != 0 && _buffer.Peek () == '\n') {
                     _buffer.Dequeue ();
                     UpdateCharQueue ();
                 }

--- a/src/OneScript.StandardLibrary/Tasks/BackgroundTasksManager.cs
+++ b/src/OneScript.StandardLibrary/Tasks/BackgroundTasksManager.cs
@@ -120,7 +120,7 @@ namespace OneScript.StandardLibrary.Tasks
                 var failedTasks = _tasks.Where(x => x.State == TaskStateEnum.CompletedWithErrors)
                     .ToList();
                 
-                if (failedTasks.Any())
+                if (failedTasks.Count != 0)
                 {
                     throw new ParametrizedRuntimeException(
                         Locale.NStr("ru = 'Задания завершились с ошибками';en = 'Tasks are completed with errors'"),

--- a/src/ScriptEngine/Compiler/ModuleDumpWriter.cs
+++ b/src/ScriptEngine/Compiler/ModuleDumpWriter.cs
@@ -129,6 +129,13 @@ namespace ScriptEngine.Compiler
                 output.WriteLine(
                     $"{i,-3}:type: {item.SystemType.Alias}, val: {item}");
             }
+            output.WriteLine(".identifiers");
+            for (int i = 0; i < module.Identifiers.Count; i++)
+            {
+                var item = module.Identifiers[i];
+                output.WriteLine(
+                    $"{i,-3}: {item}");
+            }
             output.WriteLine(".code");
             for (int i = 0; i < module.Code.Count; i++)
             {

--- a/src/ScriptEngine/Compiler/StackMachineCodeGenerator.cs
+++ b/src/ScriptEngine/Compiler/StackMachineCodeGenerator.cs
@@ -1051,7 +1051,7 @@ namespace ScriptEngine.Compiler
             var argsPassed = node.ConstructorArguments.Children.Count;
             if (argsPassed == 1)
             {
-                PushArgumentsList(node.ConstructorArguments);
+                VisitCallArgument(node.ConstructorArguments.Children[0]); ;
             }
             else if (argsPassed > 1)
             {

--- a/src/ScriptEngine/Compiler/StackMachineCodeGenerator.cs
+++ b/src/ScriptEngine/Compiler/StackMachineCodeGenerator.cs
@@ -12,7 +12,6 @@ using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
-using System.Text;
 using OneScript.Compilation;
 using OneScript.Compilation.Binding;
 using OneScript.Contexts;
@@ -126,7 +125,7 @@ namespace ScriptEngine.Compiler
 
         private void CheckForwardedDeclarations()
         {
-            if (_forwardedMethods.Count > 0)
+            if (_forwardedMethods.Count != 0)
             {
                 foreach (var item in _forwardedMethods)
                 {
@@ -477,7 +476,7 @@ namespace ScriptEngine.Compiler
 
         protected override void VisitReturnNode(BslSyntaxNode node)
         {
-            if (node.Children.Count > 0)
+            if (node.Children.Count != 0)
             {
                 VisitExpression(node.Children[0]);
                 AddCommand(OperationCode.MakeRawValue);
@@ -1085,7 +1084,7 @@ namespace ScriptEngine.Compiler
 
         private void PushTryNesting()
         {
-            if (_nestedLoops.Count > 0)
+            if (_nestedLoops.Count != 0)
             {
                 _nestedLoops.Peek().tryNesting++;
             }
@@ -1093,7 +1092,7 @@ namespace ScriptEngine.Compiler
         
         private void PopTryNesting()
         {
-            if (_nestedLoops.Count > 0)
+            if (_nestedLoops.Count != 0)
             {
                 _nestedLoops.Peek().tryNesting--;
             }

--- a/src/ScriptEngine/Compiler/StackMachineCodeGenerator.cs
+++ b/src/ScriptEngine/Compiler/StackMachineCodeGenerator.cs
@@ -489,7 +489,7 @@ namespace ScriptEngine.Compiler
         protected override void VisitRaiseNode(BslSyntaxNode node)
         {
             int arg = -1;
-            if (node.Children.Any())
+            if (node.Children.Count != 0)
             {
                 VisitExpression(node.Children[0]);
                 arg = 0;
@@ -728,24 +728,17 @@ namespace ScriptEngine.Compiler
             
             PushCallArguments(args);
             
-            var cDef = new ConstDefinition();
-            cDef.Type = DataType.String;
-            cDef.Presentation = name.GetIdentifier();
-            int lastIdentifierConst = GetConstNumber(cDef);
+            int lastIdentifierIndex = GetIdentNumber(name.GetIdentifier());
             
             if (asFunction)
-                AddCommand(OperationCode.ResolveMethodFunc, lastIdentifierConst);
+                AddCommand(OperationCode.ResolveMethodFunc, lastIdentifierIndex);
             else
-                AddCommand(OperationCode.ResolveMethodProc, lastIdentifierConst);
+                AddCommand(OperationCode.ResolveMethodProc, lastIdentifierIndex);
         }
         
         private void ResolveProperty(string identifier)
         {
-            var cDef = new ConstDefinition();
-            cDef.Type = DataType.String;
-            cDef.Presentation = identifier;
-            var identifierConstIndex = GetConstNumber(cDef);
-            AddCommand(OperationCode.ResolveProp, identifierConstIndex);
+            AddCommand(OperationCode.ResolveProp, GetIdentNumber(identifier));
         }
 
         private int PushVariable(TerminalNode node)
@@ -1327,6 +1320,19 @@ namespace ScriptEngine.Compiler
             }
             return idx;
         }
+
+        private int GetIdentNumber(string ident)
+        {
+            
+            var idx = _module.Identifiers.IndexOf(ident);
+            if (idx < 0)
+            {
+                idx = _module.Identifiers.Count;
+                _module.Identifiers.Add(ident);
+            }
+            return idx;
+        }
+
 
         private int GetMethodRefNumber(in SymbolBinding methodBinding)
         {

--- a/src/ScriptEngine/Compiler/StackMachineCodeGenerator.cs
+++ b/src/ScriptEngine/Compiler/StackMachineCodeGenerator.cs
@@ -856,11 +856,13 @@ namespace ScriptEngine.Compiler
             else
             {
                 // can be defined later
-                var forwarded = new ForwardedMethodDecl();
-                forwarded.identifier = identifier;
-                forwarded.asFunction = asFunction;
-                forwarded.location = identifierNode.Location;
-                forwarded.factArguments = argList;
+                var forwarded = new ForwardedMethodDecl
+                {
+                    identifier = identifier,
+                    asFunction = asFunction,
+                    location = identifierNode.Location,
+                    factArguments = argList
+                };
 
                 PushCallArguments(call.ArgumentList);
                 
@@ -878,17 +880,17 @@ namespace ScriptEngine.Compiler
 
         private void PushArgumentsList(BslSyntaxNode argList)
         {
-            for (int i = 0; i < argList.Children.Count; i++)
+            var arguments = argList.Children;
+            for (int i = 0; i < arguments.Count; i++)
             {
-                var passedArg = argList.Children[i];
-                VisitCallArgument(passedArg);
+                VisitCallArgument(arguments[i]);
             }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void VisitCallArgument(BslSyntaxNode passedArg)
         {
-            if (passedArg.Children.Count > 0)
+            if (passedArg.Children.Count != 0)
             {
                 VisitExpression(passedArg.Children[0]);
             }
@@ -1061,21 +1063,17 @@ namespace ScriptEngine.Compiler
         
         private void MakeNewObjectStatic(NewObjectNode node)
         {
-            var cDef = new ConstDefinition()
-            {
-                Type = DataType.String,
-                Presentation = node.TypeNameNode.GetIdentifier()
-            };
-            AddCommand(OperationCode.PushConst, GetConstNumber(cDef));
-
-            var callArgs = 0;
             if (node.ConstructorArguments != default)
             {
-                PushArgumentsList(node.ConstructorArguments);
-                callArgs = node.ConstructorArguments.Children.Count;
+                PushCallArguments(node.ConstructorArguments);
+            }
+            else
+            {
+                AddCommand(OperationCode.ArgNum, 0);
             }
 
-            AddCommand(OperationCode.NewInstance, callArgs);
+            var idNum = GetIdentNumber(node.TypeNameNode.GetIdentifier());
+            AddCommand(OperationCode.NewInstance, idNum);
         }
 
         private void ExitTryBlocks()
@@ -1323,7 +1321,6 @@ namespace ScriptEngine.Compiler
 
         private int GetIdentNumber(string ident)
         {
-            
             var idx = _module.Identifiers.IndexOf(ident);
             if (idx < 0)
             {

--- a/src/ScriptEngine/Machine/MachineInstance.cs
+++ b/src/ScriptEngine/Machine/MachineInstance.cs
@@ -1180,23 +1180,14 @@ namespace ScriptEngine.Machine
             NextInstruction();
         }
 
-        private void NewInstance(int argCount)
+        private void NewInstance(int arg)
         {
-            IValue[] argValues = new IValue[argCount];
-            // fact args
-            for (int i = argCount - 1; i >= 0; i--)
-            {
-                var argValue = _operationStack.Pop();
-                if(!argValue.IsSkippedArgument())
-                    argValues[i] = RawValue(argValue);
-            }
-
-            var typeName = _operationStack.Pop().ToString(); // is BslStringValue by code generation
+            var typeName = _module.Identifiers[arg];
             if (!_typeManager.TryGetType(typeName, out var type))
             {
                 throw RuntimeException.TypeIsNotDefined(typeName);
             }
-            
+
             // TODO убрать cast после рефакторинга ITypeFactory
             var factory = (TypeFactory)_typeManager.GetFactoryFor(type);
             var context = new TypeActivationContext
@@ -1206,7 +1197,17 @@ namespace ScriptEngine.Machine
                 Services = _process.Services,
                 CurrentProcess = _process
             };
-            
+
+            int argCount = (int)_operationStack.Pop().AsNumber();
+            IValue[] argValues = new IValue[argCount];
+            // fact args
+            for (int i = argCount - 1; i >= 0; i--)
+            {
+                var argValue = _operationStack.Pop();
+                if(!argValue.IsSkippedArgument())
+                    argValues[i] = RawValue(argValue);
+            }
+
             var instance = (IValue)factory.Activate(context, argValues);
             _operationStack.Push(instance);
             NextInstruction();

--- a/src/ScriptEngine/Machine/MachineInstance.cs
+++ b/src/ScriptEngine/Machine/MachineInstance.cs
@@ -24,6 +24,7 @@ using OneScript.Types;
 using OneScript.Values;
 using ScriptEngine.Compiler;
 using ScriptEngine.Machine.Debugger;
+using System.Dynamic;
 
 namespace ScriptEngine.Machine
 {
@@ -1182,22 +1183,6 @@ namespace ScriptEngine.Machine
 
         private void NewInstance(int arg)
         {
-            var typeName = _module.Identifiers[arg];
-            if (!_typeManager.TryGetType(typeName, out var type))
-            {
-                throw RuntimeException.TypeIsNotDefined(typeName);
-            }
-
-            // TODO убрать cast после рефакторинга ITypeFactory
-            var factory = (TypeFactory)_typeManager.GetFactoryFor(type);
-            var context = new TypeActivationContext
-            {
-                TypeName = typeName,
-                TypeManager = _typeManager,
-                Services = _process.Services,
-                CurrentProcess = _process
-            };
-
             int argCount = (int)_operationStack.Pop().AsNumber();
             IValue[] argValues = new IValue[argCount];
             // fact args
@@ -1208,8 +1193,8 @@ namespace ScriptEngine.Machine
                     argValues[i] = RawValue(argValue);
             }
 
-            var instance = (IValue)factory.Activate(context, argValues);
-            _operationStack.Push(instance);
+            var typeName = _module.Identifiers[arg];
+            _operationStack.Push(CreateInstance(typeName, argValues));
             NextInstruction();
         }
 
@@ -2396,13 +2381,19 @@ namespace ScriptEngine.Machine
                 else
                     argValues = Array.Empty<IValue>();
             }
-            
+
             var typeName = PopRawBslValue().ToString(_process);
+            _operationStack.Push(CreateInstance(typeName, argValues));
+            NextInstruction();
+        }
+
+        private IValue CreateInstance(string typeName, IValue[] args)
+        {
             if (!_typeManager.TryGetType(typeName, out var type))
             {
                 throw RuntimeException.TypeIsNotDefined(typeName);
             }
-            
+
             // TODO убрать cast после рефакторинга ITypeFactory
             var factory = (TypeFactory)_typeManager.GetFactoryFor(type);
             var context = new TypeActivationContext
@@ -2412,10 +2403,7 @@ namespace ScriptEngine.Machine
                 Services = _process.Services,
                 CurrentProcess = _process
             };
-
-            var instance = factory.Activate(context, argValues);
-            _operationStack.Push(instance);
-            NextInstruction();
+            return factory.Activate(context, args);
         }
 
         #endregion

--- a/src/ScriptEngine/Machine/MachineInstance.cs
+++ b/src/ScriptEngine/Machine/MachineInstance.cs
@@ -681,7 +681,7 @@ namespace ScriptEngine.Machine
             _operationStack.Push(_module.Constants[arg]);
             NextInstruction();
         }
-        
+
         private void PushBool(int arg)
         {
             _operationStack.Push(BslBooleanValue.Create(arg == 1));
@@ -1011,7 +1011,7 @@ namespace ScriptEngine.Machine
             var objIValue = _operationStack.Pop();
             
             var context = objIValue.AsObject();
-            var propName = _module.Constants[arg].ToString(_process);
+            var propName = _module.Identifiers[arg];
             var propNum = context.GetPropertyNumber(propName);
 
             var propReference = Variable.CreateContextPropertyReference(context, propNum, "stackvar");
@@ -1048,7 +1048,7 @@ namespace ScriptEngine.Machine
  
             var objIValue = _operationStack.Pop();
             context = objIValue.AsObject();
-            var methodName = _module.Constants[arg].ToString(_process);
+            var methodName = _module.Identifiers[arg];
             methodId = context.GetMethodNumber(methodName);
             
             if (context.DynamicMethodSignatures)
@@ -1191,7 +1191,7 @@ namespace ScriptEngine.Machine
                     argValues[i] = RawValue(argValue);
             }
 
-            var typeName = PopRawBslValue().ToString(_process);
+            var typeName = _operationStack.Pop().ToString(); // is BslStringValue by code generation
             if (!_typeManager.TryGetType(typeName, out var type))
             {
                 throw RuntimeException.TypeIsNotDefined(typeName);

--- a/src/ScriptEngine/Machine/MachineInstance.cs
+++ b/src/ScriptEngine/Machine/MachineInstance.cs
@@ -24,7 +24,6 @@ using OneScript.Types;
 using OneScript.Values;
 using ScriptEngine.Compiler;
 using ScriptEngine.Machine.Debugger;
-using System.Dynamic;
 
 namespace ScriptEngine.Machine
 {

--- a/src/ScriptEngine/Machine/MachineInstance.cs
+++ b/src/ScriptEngine/Machine/MachineInstance.cs
@@ -1134,7 +1134,7 @@ namespace ScriptEngine.Machine
             if (_currentFrame.DiscardReturnValue)
                 _operationStack.Pop();
 
-            while(_exceptionsStack.Count > 0 && _exceptionsStack.Peek().HandlerFrame == _currentFrame)
+            while(_exceptionsStack.Count != 0 && _exceptionsStack.Peek().HandlerFrame == _currentFrame)
             {
                 _exceptionsStack.Pop();
             }
@@ -1248,7 +1248,7 @@ namespace ScriptEngine.Machine
 
         private void EndTry(int arg)
         {
-            if (_exceptionsStack.Count > 0)
+            if (_exceptionsStack.Count != 0)
             {
                 var jmpInfo = _exceptionsStack.Peek();
                 if (jmpInfo.HandlerFrame == _currentFrame && arg == jmpInfo.HandlerAddress)
@@ -1371,7 +1371,7 @@ namespace ScriptEngine.Machine
         {
             var code = PopRawBslValue().ToString(_process);
             var module = CompileCached(code, CompileExecutionBatchModule);
-            if (!module.Methods.Any())
+            if (module.Methods.Count == 0)
             {
                 NextInstruction();
                 return;

--- a/src/ScriptEngine/Machine/StackRuntimeModule.cs
+++ b/src/ScriptEngine/Machine/StackRuntimeModule.cs
@@ -26,10 +26,12 @@ namespace ScriptEngine.Machine
         public int EntryMethodIndex { get; set; } = -1;
 
         public List<BslPrimitiveValue> Constants { get; } = new List<BslPrimitiveValue>();
+
+        internal List<string> Identifiers { get; } = new List<string>();
         
-        internal IList<ModuleSymbolBinding> VariableRefs { get; } = new List<ModuleSymbolBinding>();
+        internal List<ModuleSymbolBinding> VariableRefs { get; } = new List<ModuleSymbolBinding>();
         
-        internal IList<ModuleSymbolBinding> MethodRefs { get; } = new List<ModuleSymbolBinding>();
+        internal List<ModuleSymbolBinding> MethodRefs { get; } = new List<ModuleSymbolBinding>();
         
         #region IExecutableModule members
 
@@ -52,7 +54,7 @@ namespace ScriptEngine.Machine
 
         public IList<BslScriptMethodInfo> Methods { get; } = new List<BslScriptMethodInfo>();
 
-        public IList<Command> Code { get; } = new List<Command>(512);
+        public List<Command> Code { get; } = new List<Command>(512);
 
         public SourceCode Source { get; set; }
         

--- a/src/oscript/Web/Multipart/BinaryStreamStack.cs
+++ b/src/oscript/Web/Multipart/BinaryStreamStack.cs
@@ -295,7 +295,7 @@ namespace HttpMultipartParser
                 while (amountRead == 0)
                 {
                     streams.Pop();
-                    if (!streams.Any())
+                    if (streams.Count == 0)
                     {
                         hitStreamEnd = true;
                         return builder.ToArray();

--- a/src/oscript/Web/Multipart/BinaryStreamStack.cs
+++ b/src/oscript/Web/Multipart/BinaryStreamStack.cs
@@ -90,7 +90,7 @@ namespace HttpMultipartParser
         /// </returns>
         public bool HasData()
         {
-            return streams.Any();
+            return streams.Count != 0;
         }
 
         /// <summary>
@@ -144,7 +144,7 @@ namespace HttpMultipartParser
                 top.Dispose();
                 streams.Pop();
 
-                if (!streams.Any())
+                if (streams.Count == 0)
                 {
                     return -1;
                 }
@@ -182,7 +182,7 @@ namespace HttpMultipartParser
             // or untill count is satisfied
             int amountRead = 0;
             BinaryReader top = streams.Peek();
-            while (amountRead < count && streams.Any())
+            while (amountRead < count && streams.Count != 0)
             {
                 int read = top.Read(buffer, index + amountRead, count - amountRead);
                 if (read == 0)
@@ -228,7 +228,7 @@ namespace HttpMultipartParser
             // or untill count is satisfied
             int amountRead = 0;
             BinaryReader top = streams.Peek();
-            while (amountRead < count && streams.Any())
+            while (amountRead < count && streams.Count != 0)
             {
                 int read = top.Read(buffer, index + amountRead, count - amountRead);
                 if (read == 0)
@@ -396,7 +396,7 @@ namespace HttpMultipartParser
             BinaryReader top = streams.Pop();
             top.Dispose();
 
-            return streams.Any() ? streams.Peek() : null;
+            return streams.Count != 0 ? streams.Peek() : null;
         }
 
         #endregion


### PR DESCRIPTION
Поскольку имена свойств, методов, полей структур являются по определению корректными идентификаторами, их можно хранить в отдельном от произвольных констант списке в виде строк, а не преобразовывать в IValue и обратно.
То же относится и именам типов и классов.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Module dump output now includes an identifiers section for clearer visibility into compiled modules.

* **Refactor**
  * Unified identifier handling across compilation and runtime for more consistent lookups and instance creation.
  * Internal collections made more concrete to simplify initialization and use.

* **Style**
  * Numerous small conditional and initialization refinements for consistency and readability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->