### PR TITLE
Добавлен параметр завершения дочерних процессов в метод Завершить()

### DIFF
--- a/src/OneScript.StandardLibrary/Processes/ProcessContext.cs
+++ b/src/OneScript.StandardLibrary/Processes/ProcessContext.cs
@@ -196,10 +196,15 @@ namespace OneScript.StandardLibrary.Processes
 
         [ContextProperty("Имя", "Name")] public string Name => _p.ProcessName;
 
-        [ContextMethod("Завершить","Stop")]
-        public void Stop()
+        /// <summary>
+        /// Завершить процесс и, опционально, все его дочерние процессы.
+        /// </summary>
+        /// <param name="entireProcessTree">Булево. Завершить все дочерние процессы.</param>
+        /// <exception cref="AggregateException">Не все дочерние процессы удалось завершить (только при entireProcessTree = true).</exception>
+        [ContextMethod("Завершить", "Stop")]
+        public void Stop(bool entireProcessTree = false)
         {
-            _p.Kill();
+            _p.Kill(entireProcessTree);
         }
 
         public void Dispose()


### PR DESCRIPTION
## Описание изменений:
- Расширен метод `ProcessContext.Stop/Завершить`: добавлен опциональный параметр `entireProcessTree` для завершения дерева процесса.
- Для обратной совместимости сохранено поведение по умолчанию: `Stop()` завершает только текущий процесс (`entireProcessTree = false`).
- Вызов прокинут в `.NET` через `Process.Kill(entireProcessTree)`.

closes #1659

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Process termination now accepts an optional flag to control stopping the entire process tree; default behavior remains stopping only the main process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->