### PR TITLE
Проброс bsl-процесса при native-компиляции.

### DIFF
--- a/src/OneScript.Native/Compiler/MethodCompiler.cs
+++ b/src/OneScript.Native/Compiler/MethodCompiler.cs
@@ -1092,6 +1092,13 @@ namespace OneScript.Native.Compiler
             _statementBuildParts.Push(expression);
         }
 
+        private static bool HasProcessParameter(MethodInfo mi)
+        {
+            var p = mi.GetParameters();
+            if (p.Length > 0 && p[0].ParameterType == typeof(IBslProcess)) return true;
+            return false;
+        }
+
         protected override void VisitObjectProcedureCall(BslSyntaxNode node)
         {
             var target = _statementBuildParts.Pop();
@@ -1102,7 +1109,8 @@ namespace OneScript.Native.Compiler
             if (targetType.IsObjectValue())
             {
                 var methodInfo = FindMethodOfType(node, targetType, name);
-                var args = PrepareCallArguments(call.ArgumentList, methodInfo.GetParameters(), methodInfo is ContextMethodInfo { InjectsProcess: true });
+                var injectProcess = methodInfo is ContextMethodInfo { InjectsProcess: true } || HasProcessParameter(methodInfo);
+                var args = PrepareCallArguments(call.ArgumentList, methodInfo.GetParameters(), injectProcess);
 
                 _blocks.Add(Expression.Call(target, methodInfo, args));
             }

--- a/src/OneScript.Native/Compiler/MethodCompiler.cs
+++ b/src/OneScript.Native/Compiler/MethodCompiler.cs
@@ -1092,10 +1092,17 @@ namespace OneScript.Native.Compiler
             _statementBuildParts.Push(expression);
         }
 
-        private static bool HasProcessParameter(MethodInfo mi)
+        private static bool InjectedProcessNeeded(MethodInfo methodInfo)
         {
-            var p = mi.GetParameters();
-            if (p.Length > 0 && p[0].ParameterType == typeof(IBslProcess)) return true;
+            if (methodInfo is ContextMethodInfo { InjectsProcess: true })
+            {
+                return true;
+            }
+            var p = methodInfo.GetParameters();
+            if (p.Length > 0 && p[0].ParameterType == typeof(IBslProcess))
+            {
+                return true;
+            }
             return false;
         }
 
@@ -1109,7 +1116,7 @@ namespace OneScript.Native.Compiler
             if (targetType.IsObjectValue())
             {
                 var methodInfo = FindMethodOfType(node, targetType, name);
-                var injectProcess = methodInfo is ContextMethodInfo { InjectsProcess: true } || HasProcessParameter(methodInfo);
+                var injectProcess = InjectedProcessNeeded(methodInfo);
                 var args = PrepareCallArguments(call.ArgumentList, methodInfo.GetParameters(), injectProcess);
 
                 _blocks.Add(Expression.Call(target, methodInfo, args));
@@ -1176,8 +1183,8 @@ namespace OneScript.Native.Compiler
                         $"Метод {targetType}.{name} не является функцией",
                         $"Method {targetType}.{name} is not a function"), ToCodePosition(node.Location));
                 }
-            
-                var args = PrepareCallArguments(call.ArgumentList, methodInfo.GetParameters(), methodInfo is ContextMethodInfo { InjectsProcess: true });
+
+                var args = PrepareCallArguments(call.ArgumentList, methodInfo.GetParameters(), InjectedProcessNeeded(methodInfo));
                 _statementBuildParts.Push(Expression.Call(target, methodInfo, args));
             }
             else if (targetType.IsContext())
@@ -1274,7 +1281,7 @@ namespace OneScript.Native.Compiler
             }
 
             var symbol = Symbols.GetScope(binding.ScopeNumber).Methods[binding.MemberNumber];
-            var args = PrepareCallArguments(node.ArgumentList, symbol.Method.GetParameters(), symbol.Method is ContextMethodInfo { InjectsProcess: true });
+            var args = PrepareCallArguments(node.ArgumentList, symbol.Method.GetParameters(), InjectedProcessNeeded(symbol.Method));
 
             var methodInfo = symbol.Method;
             if (methodInfo is ContextMethodInfo contextMethod)

--- a/src/OneScript.Native/Compiler/MethodCompiler.cs
+++ b/src/OneScript.Native/Compiler/MethodCompiler.cs
@@ -1433,8 +1433,8 @@ namespace OneScript.Native.Compiler
                     ? ConvertToExpressionTree(passedArg.Children[0])
                     : null).ToArray();
 
-            var parametersToProcess = declaredParameters.Length;
             var declStart = injectsProcess ? 1 : 0;
+            var parametersToProcess = declaredParameters.Length - declStart;
             for (int i = 0, decl = declStart; i < parameters.Length; i++, decl++)
             {
                 if (parametersToProcess == 0)

--- a/src/Tests/OneScript.Core.Tests/HelperClasses/TestContextClass.cs
+++ b/src/Tests/OneScript.Core.Tests/HelperClasses/TestContextClass.cs
@@ -5,13 +5,14 @@ was not distributed with this file, You can obtain one
 at http://mozilla.org/MPL/2.0/.
 ----------------------------------------------------------*/
 
-using System.Collections.Generic;
 using OneScript.Contexts;
+using OneScript.Execution;
 using OneScript.Types;
 using OneScript.Values;
 using ScriptEngine.Machine;
 using ScriptEngine.Machine.Contexts;
 using ScriptEngine.Types;
+using System.Collections.Generic;
 
 namespace OneScript.Core.Tests
 {
@@ -60,7 +61,46 @@ namespace OneScript.Core.Tests
 			_indexedValues[(BslValue)index] = (BslValue)val;
 		}
 
-		[ScriptConstructor]
+        #region IBslProcessTests
+
+        [ContextMethod("Процедура0")]
+        public void Procedure0() { }
+
+        [ContextMethod("Процедура0СПроцессом")]
+        public void Procedure0WithProcess(IBslProcess process) { }
+
+        [ContextMethod("Процедура1")]
+        public void Procedure1(int intValue) { }
+
+        [ContextMethod("Процедура1СПроцессом")]
+        public void Procedure1WithProcess(IBslProcess process, int intValue) { }
+
+        [ContextMethod("Процедура1СУмолчанием")]
+        public void Procedure1WithDefault(int intValue = 0) { }
+
+        [ContextMethod("Процедура1СУмолчаниемСПроцессом")]
+        public void Procedure1WithDefaultWithProcess(IBslProcess process, int intValue = 0) { }
+
+        [ContextMethod("Функция0")]
+        public int Function0() { return 0; }
+
+        [ContextMethod("Функция0СПроцессом")]
+        public int Function0WithProcess(IBslProcess process) { return 0; }
+
+        [ContextMethod("Функция1")]
+        public int Function1(int intValue) { return intValue; }
+
+        [ContextMethod("Функция1СПроцессом")]
+        public int Function1WithProcess(IBslProcess process, int intValue) { return intValue; }
+
+        [ContextMethod("Функция1СУмолчанием")]
+        public int Function1WithDefault(int intValue = 0) { return intValue; }
+
+        [ContextMethod("Функция1СУмолчаниемСПроцессом")]
+        public int Function1WithDefaultWithProcess(IBslProcess process, int intValue = 0) { return intValue; }
+        #endregion
+
+        [ScriptConstructor]
 		public static TestContextClass Constructor()
 		{
 			return new TestContextClass

--- a/src/Tests/OneScript.Core.Tests/NativeCompilerTest.cs
+++ b/src/Tests/OneScript.Core.Tests/NativeCompilerTest.cs
@@ -868,40 +868,51 @@ namespace OneScript.Core.Tests
             array.Should().HaveCount(2);
         }
 
-        [Fact]
-        public void Can_Call_Member_ProceduresWithBslProcess()
+        [Theory]
+        [InlineData("Объект.Процедура0();")]
+        [InlineData("Объект.Процедура0СПроцессом();")]
+        [InlineData("Объект.Процедура1(1);")]
+        [InlineData("Объект.Процедура1СПроцессом(1);")]
+        [InlineData("Объект.Процедура1СУмолчанием();")]
+        [InlineData("Объект.Процедура1СУмолчаниемСПроцессом();")]
+        [InlineData("Объект.Процедура1СУмолчанием(1);")]
+        [InlineData("Объект.Процедура1СУмолчаниемСПроцессом(1);")]
+        public void Can_Call_Member_ProceduresWithBslProcess(string code)
         {
             var tm = new DefaultTypeManager();
-            var testType = tm.RegisterClass(typeof(ValueListImpl));
+            var testType = tm.RegisterClass(typeof(TestContextClass));
 
             var block = new CompiledBlock(default);
-            block.Parameters.Insert("Список", new BslTypeValue(testType));
-            // в методе SortByValue первым параметром идет IBslProcess process
-            block.CodeBlock = "Список.СортироватьПоЗначению();";
+            block.Parameters.Insert("Объект", new BslTypeValue(testType));
+            block.CodeBlock = code;
 
-            var method = block.CreateDelegate<Func<ValueListImpl, BslValue>>();
-            var testValue = new ValueListImpl();
+            var method = block.CreateDelegate<Func<TestContextClass, BslValue>>();
+            var testValue = new TestContextClass();
             method(testValue);
 
         }
 
-        [Fact]
-        public void Can_Call_Member_FunctionsWithBslProcess()
+        [Theory]
+        [InlineData("Объект.Функция0()")]
+        [InlineData("Объект.Функция0СПроцессом()")]
+        [InlineData("Объект.Функция1(1)")]
+        [InlineData("Объект.Функция1СПроцессом(1)")]
+        [InlineData("Объект.Функция1СУмолчанием()")]
+        [InlineData("Объект.Функция1СУмолчаниемСПроцессом()")]
+        [InlineData("Объект.Функция1СУмолчанием(1)")]
+        [InlineData("Объект.Функция1СУмолчаниемСПроцессом(1)")]
+        public void Can_Call_Member_FunctionsWithBslProcess(string code)
         {
             var tm = new DefaultTypeManager();
-            var targetTestType = tm.RegisterClass(typeof(ArrayImpl));
-            var testType = tm.RegisterClass(typeof(ReflectorContext));
+            var testType = tm.RegisterClass(typeof(TestContextClass));
 
             var block = new CompiledBlock(default);
-            block.Parameters.Insert("Рефлектор", new BslTypeValue(testType));
-            block.Parameters.Insert("Массив", new BslTypeValue(targetTestType));
-            // в методе CallMethod первым параметром идет IBslProcess process
-            block.CodeBlock = "Результат = Рефлектор.ВызватьМетод(Массив, \"Количество\");";
+            block.Parameters.Insert("Объект", new BslTypeValue(testType));
+            block.CodeBlock = $"Результат = {code};";
 
-            var method = block.CreateDelegate<Func<ReflectorContext, ArrayImpl, BslValue>>();
-            var reflector = ReflectorContext.CreateNew(new TypeActivationContext() { TypeManager = tm});
-            var array = new ArrayImpl();
-            method(reflector, array);
+            var method = block.CreateDelegate<Func<TestContextClass, BslValue>>();
+            var testValue = new TestContextClass();
+            method(testValue);
 
         }
 

--- a/src/Tests/OneScript.Core.Tests/NativeCompilerTest.cs
+++ b/src/Tests/OneScript.Core.Tests/NativeCompilerTest.cs
@@ -867,7 +867,44 @@ namespace OneScript.Core.Tests
 
             array.Should().HaveCount(2);
         }
-        
+
+        [Fact]
+        public void Can_Call_Member_ProceduresWithBslProcess()
+        {
+            var tm = new DefaultTypeManager();
+            var testType = tm.RegisterClass(typeof(ValueListImpl));
+
+            var block = new CompiledBlock(default);
+            block.Parameters.Insert("Список", new BslTypeValue(testType));
+            // в методе SortByValue первым параметром идет IBslProcess process
+            block.CodeBlock = "Список.СортироватьПоЗначению();";
+
+            var method = block.CreateDelegate<Func<ValueListImpl, BslValue>>();
+            var testValue = new ValueListImpl();
+            method(testValue);
+
+        }
+
+        [Fact]
+        public void Can_Call_Member_FunctionsWithBslProcess()
+        {
+            var tm = new DefaultTypeManager();
+            var targetTestType = tm.RegisterClass(typeof(ArrayImpl));
+            var testType = tm.RegisterClass(typeof(ReflectorContext));
+
+            var block = new CompiledBlock(default);
+            block.Parameters.Insert("Рефлектор", new BslTypeValue(testType));
+            block.Parameters.Insert("Массив", new BslTypeValue(targetTestType));
+            // в методе CallMethod первым параметром идет IBslProcess process
+            block.CodeBlock = "Результат = Рефлектор.ВызватьМетод(Массив, \"Количество\");";
+
+            var method = block.CreateDelegate<Func<ReflectorContext, ArrayImpl, BslValue>>();
+            var reflector = ReflectorContext.CreateNew(new TypeActivationContext() { TypeManager = tm});
+            var array = new ArrayImpl();
+            method(reflector, array);
+
+        }
+
         [Fact]
         public void Can_Call_Member_Procedures_On_Dynamics()
         {

--- a/src/Tests/OneScript.Core.Tests/NativeCompilerTest.cs
+++ b/src/Tests/OneScript.Core.Tests/NativeCompilerTest.cs
@@ -889,7 +889,6 @@ namespace OneScript.Core.Tests
             var method = block.CreateDelegate<Func<TestContextClass, BslValue>>();
             var testValue = new TestContextClass();
             method(testValue);
-
         }
 
         [Theory]
@@ -913,7 +912,26 @@ namespace OneScript.Core.Tests
             var method = block.CreateDelegate<Func<TestContextClass, BslValue>>();
             var testValue = new TestContextClass();
             method(testValue);
+        }
 
+        [Theory]
+        [InlineData("Объект.Процедура0СПроцессом(1)")]
+        [InlineData("Объект.Функция0СПроцессом(1)")]
+        [InlineData("Объект.Функция1СУмолчаниемСПроцессом(1, 2)")]
+        [InlineData("Объект.Процедура1СУмолчаниемСПроцессом(1, 2, 3);")]
+        public void Cannot_Call_Member_Procedures_With_Wrong_Argument_Count(string code)
+        {
+            var tm = new DefaultTypeManager();
+            var testType = tm.RegisterClass(typeof(TestContextClass));
+
+            var block = new CompiledBlock(default);
+            block.Parameters.Insert("Объект", new BslTypeValue(testType));
+            block.CodeBlock = code;
+
+            var runtimeException = Assert.ThrowsAny<RuntimeException>(() => {
+                var method = block.CreateDelegate<Func<TestContextClass, BslValue>>();
+            });
+            Assert.Contains("Слишком много фактических параметров", runtimeException.Message);
         }
 
         [Fact]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Calls to member procedures/functions now correctly pass the execution context when either the method requests injection or explicitly declares the context as its first parameter.
* **Tests**
  * Added tests covering member procedure/function variants (with/without explicit context parameter, defaults) to validate correct context routing.
* **Chores**
  * Extended test helper types with additional callable member variants for these scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->