### PR TITLE
Неверно был указан тип преобразования для Даты.

### DIFF
--- a/src/OneScript.Native/Compiler/MethodCompiler.cs
+++ b/src/OneScript.Native/Compiler/MethodCompiler.cs
@@ -1310,7 +1310,7 @@ namespace OneScript.Native.Compiler
                     result = DirectConversionCall(node, typeof(string));
                     break;
                 case Token.Date:
-                    result = DirectConversionCall(node, typeof(string));
+                    result = DirectConversionCall(node, typeof(DateTime));
                     break;
                 case Token.Type:
                     CheckArgumentsCount(node.ArgumentList, 1);


### PR DESCRIPTION
<img width="865" height="499" alt="Снимок экрана 2026-05-09 143235" src="https://github.com/user-attachments/assets/fb0c3616-550c-40a3-a1f7-3e79a69b57c9" />

```bsl
#native
//Д = ТекущаяДата();
Д = Дата("20250101122214");
Сообщить(Д);
Сообщить(ТипЗнч(Д));
```
делает `Д` строкой

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed date conversion to properly use DateTime format instead of string conversion, ensuring accurate handling and processing of date values throughout the application.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EvilBeaver/OneScript/pull/1676)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->