### PR TITLE
исправлен падающий тест

### DIFF
--- a/src/Tests/DocumenterTests/XmlDocConversionTest.cs
+++ b/src/Tests/DocumenterTests/XmlDocConversionTest.cs
@@ -27,7 +27,7 @@ namespace DocumenterTests
             var exampleNode = doc.Root.Elements("example").First();
 
             var converter = new XmlDocConverter(Mock.Of<IReferenceResolver>());
-            var text = converter.ConvertTextBlock(exampleNode);
+            var text = converter.ConvertTextBlock(exampleNode).ReplaceLineEndings("\n");
             var expected = 
 @"Для Каждого Переменная Из ПеременныеСреды() Цикл
     Сообщить(Переменная.Ключ + "" = "" + Переменная.Значение);


### PR DESCRIPTION
Исправлен единственный падающий тест.
Причина: XmlDocConverter.ConvertTextBlock использует StringBuilder.AppendLine, который, в свою очередь, использует установленный по умолчанию Environment.NewLine == "\r\n" в Windows. А в исходниках везде "\n"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test reliability for XML documentation conversion to ensure consistent behavior across different operating systems.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EvilBeaver/OneScript/pull/1689?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->