### PR TITLE
fix #1699: алиас ThisObject для ЭтотОбъект

### DIFF
--- a/src/OneScript.Core/Contexts/BslFieldInfo.cs
+++ b/src/OneScript.Core/Contexts/BslFieldInfo.cs
@@ -17,8 +17,8 @@ namespace OneScript.Contexts
     {
         private AnnotationHolder _annotations;
 
-        public string Alias => null;
-        
+        public abstract string Alias { get; }
+
         private AnnotationHolder Annotations
         {
             get

--- a/src/OneScript.Core/Contexts/BslScriptFieldInfo.cs
+++ b/src/OneScript.Core/Contexts/BslScriptFieldInfo.cs
@@ -23,16 +23,19 @@ namespace OneScript.Contexts
         private Type _declaringType;
         private bool _isExported;
         private string _name;
+        private string _alias;
         private Type _dataType = typeof(BslValue);
         private int _dispId = -1;
         
         internal BslScriptFieldInfo(string name)
         {
             _name = name;
+            _alias = null;
         }
 
         public override Type DeclaringType => _declaringType;
         public override string Name => _name;
+        public override string Alias => _alias;
         public override Type ReflectedType => _declaringType;
 
         public int DispatchId => _dispId;
@@ -63,6 +66,7 @@ namespace OneScript.Contexts
 
         void IBuildableMember.SetAlias(string alias)
         {
+            _alias = alias;
         }
 
         void IBuildableMember.SetExportFlag(bool isExport)

--- a/src/ScriptEngine/Machine/Contexts/ThisAwareScriptedObjectBase.cs
+++ b/src/ScriptEngine/Machine/Contexts/ThisAwareScriptedObjectBase.cs
@@ -99,7 +99,7 @@ namespace ScriptEngine.Machine.Contexts
                 .Name(THISOBJ_RU)
                 .Alias(THISOBJ_EN)
                 .ValueType(typeof(ThisAwareScriptedObjectBase))
-                .SetDispatchingIndex(0)
+                .SetDispatchingIndex(THISOBJ_VARIABLE_INDEX)
                 .Build()
                 .ToSymbol());
         }


### PR DESCRIPTION
Возможность добавлять алиасы для локальных переменных модуля

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved field alias handling to ensure module fields properly track and manage alias values.
  * Enhanced consistency in compile-time symbol generation for object properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->