### PR TITLE
Исправить CanInjectContext_As_Symbols после добавления WriteJSONDate

### DIFF
--- a/src/Tests/OneScript.Core.Tests/NativeCompilerTest.cs
+++ b/src/Tests/OneScript.Core.Tests/NativeCompilerTest.cs
@@ -61,8 +61,9 @@ namespace OneScript.Core.Tests
             var context = new GlobalJsonFunctions();
             var scope = SymbolScope.FromObject(context);
 
-            scope.Methods.Should().HaveCount(3);
+            scope.Methods.Should().HaveCount(4);
             scope.Methods.IndexOf("ЗаписатьJSON").Should().BeGreaterOrEqualTo(0);
+            scope.Methods.IndexOf("ЗаписатьДатуJSON").Should().BeGreaterOrEqualTo(0);
         }
 
         [Fact]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Проблема

Тест `CanInjectContext_As_Symbols` падал с ошибкой:

```
Expected scope.Methods to contain 3 item(s), but found 4.
```

После merge PR #1711 в `GlobalJsonFunctions` появился четвёртый метод с атрибутом `[ContextMethod]` — `ЗаписатьДатуJSON` / `WriteJSONDate`, но ожидаемое количество методов в тесте не обновили.

## Решение

- Заменено `HaveCount(3)` на `HaveCount(4)`
- Добавлена проверка наличия метода `ЗаписатьДатуJSON` в области символов
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5aa9d9dc-403f-48b4-b2ba-5c1e67e499ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5aa9d9dc-403f-48b4-b2ba-5c1e67e499ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated compiler validation to cover an additional injected date-writing method.
  * Expanded expectations to confirm four injected methods are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->