### PR TITLE
ArgumentsParser поддерживает экранирование кавычки удвоением

### DIFF
--- a/src/OneScript.StandardLibrary/Processes/ArgumentsParser.cs
+++ b/src/OneScript.StandardLibrary/Processes/ArgumentsParser.cs
@@ -42,10 +42,19 @@ namespace OneScript.StandardLibrary.Processes
             }
             
             _currentArgument.Clear();
-            
-            foreach (var currentChar in _input)
+
+            for (var i = 0; i < _input.Length; i++)
             {
-                if (char.IsWhiteSpace(currentChar) && !_isInQuotes)
+                var currentChar = _input[i];
+
+                if (_isInQuotes && currentChar == _currentQuote
+                    && i + 1 < _input.Length && _input[i + 1] == _currentQuote)
+                {
+                    // удвоенная кавычка внутри кавычек - экранированная кавычка
+                    PushChar(currentChar);
+                    i++;
+                }
+                else if (char.IsWhiteSpace(currentChar) && !_isInQuotes)
                 {
                     PushArgument();
                 }

--- a/src/Tests/OneScript.Core.Tests/ArgumentParserTests.cs
+++ b/src/Tests/OneScript.Core.Tests/ArgumentParserTests.cs
@@ -20,6 +20,9 @@ public class ArgumentParserTests
     [InlineData("-c \"'oscript' -version\"", "-c", "'oscript' -version")]
     [InlineData("'aaa\"", "aaa\"")]
     [InlineData(" ")]
+    [InlineData("-c \"Сообщить(\"\"привет\"\")\"", "-c", "Сообщить(\"привет\")")]
+    [InlineData("-c 'it''s fine'", "-c", "it's fine")]
+    [InlineData("\"aaa\"\"\"", "aaa\"")]
     public void Should_Parse_Arguments(string input, params string[] expected)
     {
         var parser = new ArgumentsParser(input);


### PR DESCRIPTION
## Проблема

На не-Windows системах `СоздатьПроцесс` разбирает командную строку через
`ArgumentsParser`, который трактует удвоенную кавычку внутри кавычек как
«закрыть и снова открыть», схлопывая её в ничто:

```
-c "Сообщить(""привет"")"   →   -c  Сообщить(привет)
```

Из-за этого на Linux CI стабильно падает `ТестДолжен_РаботатьСEncoding` из
`tests/cli-eval.os` (добавлен в #1724): дочерний oscript получает код без
кавычек и завершается с ошибкой `Symbol not found: привет`. На Windows бага
нет — там аргументы передаются сырой строкой и разбираются по правилам
`CommandLineToArgvW`, где `""` внутри кавычек — литеральная кавычка.

## Решение

Удвоенная кавычка внутри кавычек теперь даёт литеральную кавычку (lookahead
на следующий символ), что совпадает с поведением разбора на Windows.
Существующие кейсы разбора не изменились (покрыты имеющимися тестами),
добавлены тесты на экранирование для обоих видов кавычек и на хвостовую
экранированную кавычку.

Claude-Session: https://claude.ai/code/session_013YSVPuji9Ge244GRqfawP9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command-line argument parsing for escaped quotes within quoted values.
  * Supports escaped single and double quotes, including trailing escaped quotes.

* **Tests**
  * Added coverage for multiple escaped-quote scenarios to help ensure reliable argument handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->