### PR TITLE
Владение engine и единый прогон процесса (RunProcess)

### DIFF
--- a/src/ScriptEngine.HostedScript/HostedScriptEngine.cs
+++ b/src/ScriptEngine.HostedScript/HostedScriptEngine.cs
@@ -96,19 +96,11 @@ namespace ScriptEngine.HostedScript
         /// <returns>Процесс, готовый к вызову <see cref="Process.Start"/>.</returns>
         /// <remarks>
         /// При ошибке компиляции или подготовки исключение пробрасывается вызывающему коду.
-        /// Уведомление отладчика о завершении процесса выполняет вызывающий код
-        /// (например, <see cref="RunProcess"/>).
         /// </remarks>
         public Process CreateProcess(IHostApplication host, SourceCode src)
         {
             Initialize();
             SetGlobalEnvironment(host, src);
-            
-            if (_engine.Debugger.IsEnabled)
-            {
-                _engine.Debugger.Start();
-                _engine.Debugger.GetSession().WaitReadyToRun();
-            }
 
             var compilerSvc = GetCompilerService();
             return Process.Create(_engine, compilerSvc, src);
@@ -124,7 +116,8 @@ namespace ScriptEngine.HostedScript
         /// после вывода информации об исключении через <see cref="IHostApplication.ShowExceptionInfo"/>.
         /// </returns>
         /// <remarks>
-        /// Уведомляет отладчик о завершении процесса как при успешном, так и при аварийном исходе.
+        /// Управляет сессией отладчика: старт и ожидание готовности перед созданием процесса,
+        /// уведомление о завершении при любом исходе.
         /// Прерывание скрипта (<see cref="ScriptInterruptionException"/>) обрабатывается в <see cref="Process.Start"/>
         /// и возвращается как штатный код выхода.
         /// </remarks>
@@ -132,6 +125,12 @@ namespace ScriptEngine.HostedScript
         {
             try
             {
+                if (_engine.Debugger.IsEnabled)
+                {
+                    _engine.Debugger.Start();
+                    _engine.Debugger.GetSession().WaitReadyToRun();
+                }
+
                 var process = CreateProcess(host, source);
                 var exitCode = process.Start();
                 _engine.Debugger.NotifyProcessExit(exitCode);

--- a/src/ScriptEngine.HostedScript/HostedScriptEngine.cs
+++ b/src/ScriptEngine.HostedScript/HostedScriptEngine.cs
@@ -12,7 +12,6 @@ using OneScript.Commons;
 using OneScript.Compilation;
 using OneScript.Contexts;
 using OneScript.DependencyInjection;
-using OneScript.Execution;
 using OneScript.StandardLibrary;
 using OneScript.StandardLibrary.Tasks;
 using ScriptEngine.Machine.Contexts;
@@ -89,6 +88,17 @@ namespace ScriptEngine.HostedScript
             return compilerSvc;
         }
 
+        /// <summary>
+        /// Создаёт процесс выполнения скрипта: инициализация, компиляция исходника, подготовка к запуску.
+        /// </summary>
+        /// <param name="host">Хост-приложение для взаимодействия со скриптом.</param>
+        /// <param name="src">Исходный код скрипта.</param>
+        /// <returns>Процесс, готовый к вызову <see cref="Process.Start"/>.</returns>
+        /// <remarks>
+        /// При ошибке компиляции или подготовки исключение пробрасывается вызывающему коду.
+        /// Уведомление отладчика о завершении процесса выполняет вызывающий код
+        /// (например, <see cref="RunProcess"/>).
+        /// </remarks>
         public Process CreateProcess(IHostApplication host, SourceCode src)
         {
             Initialize();
@@ -102,18 +112,40 @@ namespace ScriptEngine.HostedScript
 
             var compilerSvc = GetCompilerService();
             DefineConstants(compilerSvc);
-            IExecutableModule module;
             var bslProcess = _engine.NewProcess();
+            var module = compilerSvc.Compile(src, bslProcess);
+            return InitProcess(bslProcess, module);
+        }
+
+        /// <summary>
+        /// Создаёт и запускает процесс скрипта, возвращает код завершения.
+        /// </summary>
+        /// <param name="host">Хост-приложение для взаимодействия со скриптом.</param>
+        /// <param name="source">Исходный код скрипта.</param>
+        /// <returns>
+        /// Код завершения скрипта; при ошибке создания/выполнения — <c>1</c>
+        /// после вывода информации об исключении через <see cref="IHostApplication.ShowExceptionInfo"/>.
+        /// </returns>
+        /// <remarks>
+        /// Уведомляет отладчик о завершении процесса как при успешном, так и при аварийном исходе.
+        /// Прерывание скрипта (<see cref="ScriptInterruptionException"/>) обрабатывается в <see cref="Process.Start"/>
+        /// и возвращается как штатный код выхода.
+        /// </remarks>
+        public int RunProcess(IHostApplication host, SourceCode source)
+        {
             try
             {
-                module = compilerSvc.Compile(src, bslProcess);
+                var process = CreateProcess(host, source);
+                var exitCode = process.Start();
+                _engine.Debugger.NotifyProcessExit(exitCode);
+                return exitCode;
             }
-            catch (CompilerException)
+            catch (Exception e)
             {
                 _engine.Debugger.NotifyProcessExit(1);
-                throw;
+                host.ShowExceptionInfo(e);
+                return 1;
             }
-            return InitProcess(bslProcess, host, module);
         }
 
         private void DefineConstants(ICompilerFrontend compilerSvc)
@@ -139,11 +171,11 @@ namespace ScriptEngine.HostedScript
             _globalCtx.InitInstance();
         }
 
-        private Process InitProcess(IBslProcess bslProcess, IHostApplication host, IExecutableModule module)
+        private Process InitProcess(IBslProcess bslProcess, IExecutableModule module)
         {
             Initialize();
             
-            var process = new Process(bslProcess, host, module, _engine);
+            var process = new Process(bslProcess, module, _engine);
             return process;
         }
 

--- a/src/ScriptEngine.HostedScript/HostedScriptEngine.cs
+++ b/src/ScriptEngine.HostedScript/HostedScriptEngine.cs
@@ -84,7 +84,7 @@ namespace ScriptEngine.HostedScript
         {
             var compilerSvc = _engine.GetCompilerService();
             compilerSvc.FillSymbols(typeof(UserScriptContextInstance));
-            
+
             return compilerSvc;
         }
 
@@ -112,9 +112,7 @@ namespace ScriptEngine.HostedScript
 
             var compilerSvc = GetCompilerService();
             DefineConstants(compilerSvc);
-            var bslProcess = _engine.NewProcess();
-            var module = compilerSvc.Compile(src, bslProcess);
-            return InitProcess(bslProcess, module);
+            return Process.Create(_engine, compilerSvc, src);
         }
 
         /// <summary>
@@ -169,14 +167,6 @@ namespace ScriptEngine.HostedScript
             _globalCtx.ApplicationHost = host;
             _globalCtx.CodeSource = src;
             _globalCtx.InitInstance();
-        }
-
-        private Process InitProcess(IBslProcess bslProcess, IExecutableModule module)
-        {
-            Initialize();
-            
-            var process = new Process(bslProcess, module, _engine);
-            return process;
         }
 
         public void Dispose()

--- a/src/ScriptEngine.HostedScript/HostedScriptEngine.cs
+++ b/src/ScriptEngine.HostedScript/HostedScriptEngine.cs
@@ -84,7 +84,7 @@ namespace ScriptEngine.HostedScript
         {
             var compilerSvc = _engine.GetCompilerService();
             compilerSvc.FillSymbols(typeof(UserScriptContextInstance));
-
+            DefineConstants(compilerSvc);
             return compilerSvc;
         }
 
@@ -111,7 +111,6 @@ namespace ScriptEngine.HostedScript
             }
 
             var compilerSvc = GetCompilerService();
-            DefineConstants(compilerSvc);
             return Process.Create(_engine, compilerSvc, src);
         }
 

--- a/src/ScriptEngine.HostedScript/Process.cs
+++ b/src/ScriptEngine.HostedScript/Process.cs
@@ -12,11 +12,10 @@ namespace ScriptEngine.HostedScript
 {
     public class Process
     {
-        ScriptingEngine _engine;
-
+        readonly ScriptingEngine _engine;
         readonly IHostApplication _host;
         readonly IExecutableModule _module;
-        private IBslProcess _bslProcess;
+        private readonly IBslProcess _bslProcess;
 
         internal Process(
             IBslProcess process,
@@ -51,8 +50,6 @@ namespace ScriptEngine.HostedScript
             finally
             {
                 _engine.Debugger.NotifyProcessExit(exitCode);
-                _engine.Dispose();
-                _engine = null;
             }
 
             return exitCode;

--- a/src/ScriptEngine.HostedScript/Process.cs
+++ b/src/ScriptEngine.HostedScript/Process.cs
@@ -4,7 +4,10 @@ Mozilla Public License, v.2.0. If a copy of the MPL
 was not distributed with this file, You can obtain one 
 at http://mozilla.org/MPL/2.0/.
 ----------------------------------------------------------*/
+
+using OneScript.Compilation;
 using OneScript.Execution;
+using OneScript.Sources;
 using ScriptEngine.Machine;
 
 namespace ScriptEngine.HostedScript
@@ -14,11 +17,11 @@ namespace ScriptEngine.HostedScript
     /// </summary>
     public class Process
     {
-        readonly ScriptingEngine _engine;
-        readonly IExecutableModule _module;
+        private readonly ScriptingEngine _engine;
+        private readonly IExecutableModule _module;
         private readonly IBslProcess _bslProcess;
 
-        internal Process(
+        private Process(
             IBslProcess process,
             IExecutableModule src,
             ScriptingEngine runtime)
@@ -26,6 +29,19 @@ namespace ScriptEngine.HostedScript
             _engine = runtime;
             _module = src;
             _bslProcess = process;
+        }
+
+        /// <summary>
+        /// Создаёт процесс: выделяет runtime-процесс, компилирует исходник, готовит к запуску.
+        /// </summary>
+        internal static Process Create(
+            ScriptingEngine engine,
+            ICompilerFrontend compiler,
+            SourceCode source)
+        {
+            var bslProcess = engine.NewProcess();
+            var module = compiler.Compile(source, bslProcess);
+            return new Process(bslProcess, module, engine);
         }
 
         /// <summary>
@@ -49,6 +65,5 @@ namespace ScriptEngine.HostedScript
                 return e.ExitCode;
             }
         }
-
     }
 }

--- a/src/ScriptEngine.HostedScript/Process.cs
+++ b/src/ScriptEngine.HostedScript/Process.cs
@@ -4,55 +4,50 @@ Mozilla Public License, v.2.0. If a copy of the MPL
 was not distributed with this file, You can obtain one 
 at http://mozilla.org/MPL/2.0/.
 ----------------------------------------------------------*/
-using System;
 using OneScript.Execution;
 using ScriptEngine.Machine;
 
 namespace ScriptEngine.HostedScript
 {
+    /// <summary>
+    /// Скомпилированный процесс выполнения скрипта.
+    /// </summary>
     public class Process
     {
         readonly ScriptingEngine _engine;
-        readonly IHostApplication _host;
         readonly IExecutableModule _module;
         private readonly IBslProcess _bslProcess;
 
         internal Process(
             IBslProcess process,
-            IHostApplication host,
             IExecutableModule src,
             ScriptingEngine runtime)
         {
-            _host = host;
             _engine = runtime;
             _module = src;
             _bslProcess = process;
         }
 
+        /// <summary>
+        /// Запускает выполнение скрипта.
+        /// </summary>
+        /// <returns>
+        /// <c>0</c> при успешном завершении; код выхода при прерывании скрипта.
+        /// </returns>
+        /// <remarks>
+        /// Прочие исключения пробрасываются вызывающему коду.
+        /// </remarks>
         public int Start()
         {
-            int exitCode = 0;
-
             try
             {
                 _engine.NewObject(_module, _bslProcess);
-                exitCode = 0;
+                return 0;
             }
             catch (ScriptInterruptionException e)
             {
-                exitCode = e.ExitCode;
+                return e.ExitCode;
             }
-            catch (Exception e)
-            {
-                _host.ShowExceptionInfo(e);
-                exitCode = 1;
-            }
-            finally
-            {
-                _engine.Debugger.NotifyProcessExit(exitCode);
-            }
-
-            return exitCode;
         }
 
     }

--- a/src/TestApp/MainWindow.xaml.cs
+++ b/src/TestApp/MainWindow.xaml.cs
@@ -410,11 +410,18 @@ namespace TestApp
 
         public void Echo(string str, MessageStatusEnum status = MessageStatusEnum.Ordinary)
         {
-            _output.Dispatcher.BeginInvoke(new Action(() =>
+            void Append()
             {
                 _output.AppendText(str + '\n');
                 _output.ScrollToEnd();
-            }));
+            }
+
+            // RunProcess вызывается с UI-потока: без синхронной записи
+            // ShowExceptionInfo оказывается после "Error detected" / "Script completed".
+            if (_output.Dispatcher.CheckAccess())
+                Append();
+            else
+                _output.Dispatcher.BeginInvoke(new Action(Append));
         }
 
         public void ShowExceptionInfo(Exception exc)

--- a/src/TestApp/MainWindow.xaml.cs
+++ b/src/TestApp/MainWindow.xaml.cs
@@ -159,7 +159,7 @@ namespace TestApp
         
         private void Button_Click(object sender, RoutedEventArgs e)
         {
-            var hostedScript = CreateEngine();
+            using var hostedScript = CreateEngine();
             
             hostedScript.Initialize();
             var src = hostedScript.Loader.FromString(txtCode.Text);
@@ -205,7 +205,7 @@ namespace TestApp
 
             var host = new Host(result, l_args.ToArray());
             SystemLogger.SetWriter(host);
-            var hostedScript = CreateEngine();
+            using var hostedScript = CreateEngine();
             
             var src = SourceCodeBuilder.Create()
                 .FromSource(new EditedFileSource(txtCode.Text, _currentDocPath))

--- a/src/TestApp/MainWindow.xaml.cs
+++ b/src/TestApp/MainWindow.xaml.cs
@@ -212,20 +212,9 @@ namespace TestApp
                 .WithName(_currentDocPath)
                 .Build();
 
-            Process process = null;
-            try
-            {
-                process = hostedScript.CreateProcess(host, src);
-            }
-            catch (Exception exc)
-            {
-                host.Echo(exc.Message);
-                return;
-            }
-
             result.AppendText("Script started: " + DateTime.Now.ToString() + "\n");
             sw.Start();
-            var returnCode = process.Start();
+            var returnCode = hostedScript.RunProcess(host, src);
             sw.Stop();
             if (returnCode != 0)
             {
@@ -233,7 +222,6 @@ namespace TestApp
             }
             result.AppendText("\nScript completed: " + DateTime.Now.ToString());
             result.AppendText("\nDuration: " + sw.Elapsed.ToString() + "\n");
-            
         }
 
         private static string GetFileDialogFilter()

--- a/src/oscript/CgiBehavior.cs
+++ b/src/oscript/CgiBehavior.cs
@@ -68,7 +68,7 @@ namespace oscript
 					e.AddAssembly(GetType().Assembly);
 				});
 
-			var engine = ConsoleHostBuilder.Build(builder);
+			using var engine = ConsoleHostBuilder.Build(builder);
 
 			var request = new WebRequestContext(engine.Services.Resolve<IBinaryDataMemoryLimit>().MaxBytesInMemory);
 			engine.InjectGlobalProperty("ВебЗапрос", "WebRequest", request, true);

--- a/src/oscript/CgiBehavior.cs
+++ b/src/oscript/CgiBehavior.cs
@@ -74,20 +74,7 @@ namespace oscript
 			engine.InjectObject(this);
 
 			var source = engine.Loader.FromFile(scriptFile);
-
-			Process process;
-
-			try
-			{
-				process = engine.CreateProcess(this, source);
-			}
-			catch (Exception e)
-			{
-				ShowExceptionInfo(e);
-				return 1;
-			}
-
-			var exitCode = process.Start();
+			var exitCode = engine.RunProcess(this, source);
 
 			if (!_isContentEchoed)
 				Echo("");

--- a/src/oscript/CgiBehavior.cs
+++ b/src/oscript/CgiBehavior.cs
@@ -69,8 +69,7 @@ namespace oscript
 				});
 
 			using var engine = ConsoleHostBuilder.Build(builder);
-
-			var request = new WebRequestContext(engine.Services.Resolve<IBinaryDataMemoryLimit>().MaxBytesInMemory);
+			using var request = new WebRequestContext(engine.Services.Resolve<IBinaryDataMemoryLimit>().MaxBytesInMemory);
 			engine.InjectGlobalProperty("ВебЗапрос", "WebRequest", request, true);
 			engine.InjectObject(this);
 
@@ -93,8 +92,6 @@ namespace oscript
 			if (!_isContentEchoed)
 				Echo("");
 
-			request.Dispose();
-			
 			return exitCode;
 		}
 

--- a/src/oscript/CheckSyntaxBehavior.cs
+++ b/src/oscript/CheckSyntaxBehavior.cs
@@ -28,7 +28,7 @@ namespace oscript
 		public override int Execute()
 		{
 			var builder = ConsoleHostBuilder.Create(_path);
-			var hostedScript = ConsoleHostBuilder.Build(builder);
+			using var hostedScript = ConsoleHostBuilder.Build(builder);
 			hostedScript.Initialize();
 
 			if (_isCgi)

--- a/src/oscript/ConsoleApplicationHost.cs
+++ b/src/oscript/ConsoleApplicationHost.cs
@@ -33,19 +33,7 @@ namespace oscript
         public int RunProcess(HostedScriptEngine engine, SourceCode source)
         {
             SystemLogger.SetWriter(this);
-
-            Process process;
-            try
-            {
-                process = engine.CreateProcess(this, source);
-            }
-            catch (Exception e)
-            {
-                ShowExceptionInfo(e);
-                return 1;
-            }
-
-            return process.Start();
+            return engine.RunProcess(this, source);
         }
     }
 }

--- a/src/oscript/ShowCompiledBehavior.cs
+++ b/src/oscript/ShowCompiledBehavior.cs
@@ -23,7 +23,7 @@ namespace oscript
 		public override int Execute()
 		{
 			var builder = ConsoleHostBuilder.Create(_path);
-			var hostedScript = ConsoleHostBuilder.Build(builder);
+			using var hostedScript = ConsoleHostBuilder.Build(builder);
 			hostedScript.Initialize();
 			
 			var source = hostedScript.Loader.FromFile(_path);


### PR DESCRIPTION
В предыдущем PR #1724 был коммент:

> Это начинает дублироваться с ExecuteScriptBehavior, кажется, что надо реализацию хоста вынести уже в отдельный класс

Посмотрел, где еще есть дублирование логики.

В итоге убрано дублирование поведения в методах Execute между всеми Behavior. Теперь вызов везде одинаков:
```
var exitCode = engine.RunProcess(this, source);
```
Методы запуска стали легче. 

В HostedScriptEngine:
* Жизнь сессии отладчика теперь собрана в одном месте. Раньше была раскидана по нескольким методам.
* Создание и получение CompilerService собрано во одном методе. Раньше было отдельное поведение для внешних и внутренних вызов. Тут поменяется поведение!
* При создании процесса (CreateProcess)  дважды вызывался Initialize: в самом CreateProcess и дополнительно внутри InitProcess

В остальном:
* Упрощено владение disposable объектом WebRequestContext
* Аналогично для объекта ScriptingEngine. Это убрало "ранний" Dispose в Process и разгрузило этот объект. 

## Summary

**Рефакторинг:**

- Для `ConsoleApplicationHost`, `CgiBehavior` и TestApp (`MainWindow`) владение запуском процесса собрано в `RunProcess`: create → start, обработка ошибок.
- Владение сессией отладчика собрано в `RunProcess`: `Start` / `WaitReadyToRun` / `NotifyProcessExit`.
- Роли `Process` / `CreateProcess` / call sites выровнены.
- CGI — `using var` для гарантированного `Dispose` engine и `WebRequestContext`.

**Изменение поведения:**

- `DefineConstants` (cfg + `MONO`) применяется через `GetCompilerService` — `-check` и show-compiled получают те же preprocessor-символы, что и запуск скрипта.

**Прочее:**

- Убран двойной `Initialize` при создании процесса — формально меняет число вызовов, по сути устранение дубля без смены семантики.

## Изменение поведения

### `DefineConstants` в `GetCompilerService`

Раньше `#define` из `oscript.cfg` и `MONO` добавлялись только в `CreateProcess` (путь запуска).  
`-check` и show-compiled вызывали `GetCompilerService()` без этих символов — результат проверки/дампа мог не совпадать с реальным прогоном.

Теперь define задаются в `GetCompilerService()`; затронуты `-check`, show-compiled и run.

## Рефакторинг (без изменения поведения)

### Владение engine

- Из `Process.Start` убран `Dispose` engine; остаётся выполнение и `ScriptInterruptionException`.
- Call sites: `using` у создателя (Execute*, CGI, check/compile, TestApp) — тот же контракт владения, явнее в коде.

### CGI / `WebRequestContext`

Раньше при ошибке create был `return 1` до `request.Dispose()`, engine не освобождался. Логика скрипта та же; исправлен только порядок освобождения ресурсов (`using var engine` + `using var request`).

### `RunProcess`

Единая точка полного прогона: **владение runtime и сессия отладчика** в одном методе (эквивалент прежней цепочки create + start + show error + debugger, раньше размазанной по `CreateProcess` и `Process.Start`):

1. при включённом отладчике — `Start` + `WaitReadyToRun`;
2. `CreateProcess` + `Process.Start`;
3. `NotifyProcessExit` при успехе и при ошибке;
4. при исключении — `ShowExceptionInfo`, код `1`.

Console (`ConsoleApplicationHost`), CGI, TestApp — через `RunProcess`.  
`CreateProcess` — env + compile, без debugger (сессия целиком в `RunProcess`).

### Роли `Process`

- `Process.Create(engine, compiler, source)` — `NewProcess` + `Compile`.
- `Start()` — `NewObject`; interruption → код выхода; без host и без notify отладчика.

## Контракт API (кратко)

| API | Ответственность |
|-----|-----------------|
| `CreateProcess` | env + compile → `Process` |
| `RunProcess` | полный прогон + ошибки + debugger session |
| `Process.Start` | исполнение модуля |

## Test plan

**Регрессия (рефакторинг):**

- [x] Обычный запуск скрипта из файла (`oscript script.os`) — BSL 1228 ✅ + smoke
- [x] `-c` — smoke + `tests/cli-eval.os` (4 ✅)
- [x] CGI-сценарий (запрос + корректное закрытие) — `tests/cgi-output.os` (7 ✅)
- [ ] TestApp: run + ошибки compile/runtime — нужна ручная проверка GUI
- [ ] `-debug`: attach, wait, завершение сессии — нужна сессия отладчика
- [x] Codestat после прогона (engine жив до конца `using`) — smoke `-codestat=<file>` → JSON записан

**Изменение поведения (`DefineConstants`):**

- [x] `-check` с `#Если` / define из `oscript.cfg` — с `preprocessor.define=MYDEF` ok; без define — ошибка в отброшенной ветке
- [x] show-compiled (`-compile`) при тех же define — константа `ok` в дампе только при активном define

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined script execution through a unified process-running flow.
  * Centralized debugging coordination and process exit-code handling.
  * Standardized automatic cleanup of script engines and runtime resources.

* **Bug Fixes**
  * Improved console output ordering when messages are written from the user interface thread, helping ensure status messages and exception details appear in the correct sequence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->